### PR TITLE
Add VS Code + Calva dev setup guide

### DIFF
--- a/docs/dev-setup-vscode.md
+++ b/docs/dev-setup-vscode.md
@@ -1,0 +1,43 @@
+# VS Code + Calva
+
+Editor-specific notes for contributors using VS Code with [Calva](https://calva.io/). See [dev-setup.md](dev-setup.md) for general environment setup (MongoDB, env vars, etc.).
+
+## Install Calva
+
+Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva).
+
+## Connecting to the REPL
+
+Calva's **Jack-In** command does not source `bin/.devenv`, so the app will be missing required env vars (notably `MONGO_URL`) at startup. Instead:
+
+1. Start the REPL manually in a terminal (see [dev-setup.md](dev-setup.md#starting-the-repl))
+2. Run **Calva: Connect to a Running REPL Server** from the command palette
+3. Choose **Generic** → enter `localhost` and the port from `.nrepl-port`
+
+### Alternative: Configure Jack-In env vars
+
+If you prefer Jack-In, you can copy the env vars from `bin/.devenv` into your VS Code settings so Calva provides them at startup:
+
+```json
+{
+  "calva.jackInEnv": {
+    "MONGO_URL": "mongodb://localhost:27017/clojuredocs",
+    "ALLOW_ROBOTS": "true"
+  }
+}
+```
+
+See `bin/.devenv` for the full list of required variables. Copy the values from there. (Note: the credentials in `bin/.devenv` are dummy dev-only values, not production secrets — but it's still good practice to reference the source file rather than duplicating values.)
+
+## Paredit
+
+Calva includes Paredit for structural editing. If you're used to Emacs keybindings, you may want to add `Ctrl+K` for structural kill:
+
+```json
+// keybindings.json
+{
+  "key": "ctrl+k",
+  "command": "paredit.killRight",
+  "when": "calva:keybindingsEnabled && editorLangId =~ /clojure|clojurescript/"
+}
+```

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,73 @@
+# Dev Environment Setup
+
+Supplementary notes for getting a local development environment running. See also the [README](../README.md#dev) for the quick-start.
+
+## Prerequisites
+
+- Java (JDK 8+)
+- [Leiningen](https://leiningen.org)
+- MongoDB running locally
+
+## MongoDB
+
+Start MongoDB if it isn't already running:
+
+```bash
+mongod --dbpath ./dev-db
+```
+
+Check if it's running: `pgrep -f mongod`
+
+### Seeding the Database
+
+On first setup (or to reset), seed from the bundled production export:
+
+```bash
+bin/db-reset
+```
+
+This runs `mongorestore` against `data/mongodb/`. Verify with:
+
+```bash
+mongosh --eval "db.stats()" mongodb://localhost:27017/clojuredocs
+```
+
+## Environment Variables
+
+The app requires several env vars (`MONGO_URL`, `SESSION_KEY`, `GH_CLIENT_ID`, `ALLOW_ROBOTS`, etc.). Dev defaults live in `bin/.devenv`. Source it before starting a REPL:
+
+```bash
+source bin/.devenv
+```
+
+Without these, the app will crash on startup. The most common symptom is:
+
+```
+No implementation of method: :named of protocol:
+  #'somnium.congomongo/StringNamed found for class: nil
+```
+
+This means `MONGO_URL` is not set.
+
+## Starting the REPL
+
+`bin/dev` uses `foreman` to start everything (REPL, CLJS compiler, etc.). For a lighter backend-only REPL:
+
+```bash
+source bin/.devenv && lein repl :headless
+```
+
+The nREPL port is written to `.nrepl-port`.
+
+The `:repl-options :init` in `project.clj` loads `reup.clj` on REPL start, which automatically starts the web server and sets up namespace reloading. If you need to start the server manually:
+
+```clojure
+(require 'clojuredocs.main)
+(clojuredocs.main/start-app)
+```
+
+## Web Server
+
+- Default port: **8080** (or whatever `PORT` env var is set to)
+- `bin/dev` sets `PORT=4000`; `bin/.devenv` does not set `PORT`
+- Visit http://localhost:8080 (or your configured port) to verify


### PR DESCRIPTION
# Add VS Code + Calva dev setup guide
Adds dev-setup-vscode.md with notes for contributors using VS Code + Calva instead of Emacs/CIDER.

What's included

- Prerequisites and database seeding
- How to start a REPL with the required env vars from .devenv
- Why Calva Jack-In doesn't work out of the box (missing env vars) and the workaround (connect to a running REPL)
- Manual web server startup from the REPL
- Troubleshooting: missing MONGO_URL, MongoDB not running

## Context
While testing PR #3, I set up the project from scratch using VS Code + Calva and hit several friction points — mostly around env var configuration and Calva's Jack-In not sourcing .devenv. The existing README covers dev + foreman, which works, but doesn't address editor-REPL integration for non-Emacs setups. This doc fills that gap.