### PR TITLE
Correct gravatar size for Recently Updated

### DIFF
--- a/src/clj/clojuredocs/pages/intro.clj
+++ b/src/clj/clojuredocs/pages/intro.clj
@@ -11,7 +11,7 @@
 (defmethod $render-recently-updated :example
   [{:keys [var author created-at]}]
   [:div.recently-updated
-   (util/$avatar author)
+   (util/$avatar author {:size 48})
    [:span.content
     (:login author)
     " authored an example for "
@@ -27,7 +27,7 @@
 (defmethod $render-recently-updated :see-also
   [{:keys [from-var to-var author created-at]}]
   [:div.recently-updated
-   (util/$avatar author)
+   (util/$avatar author {:size 48})
    [:span.content
     (:login author)
     " added a see-also from "
@@ -48,7 +48,7 @@
 (defmethod $render-recently-updated :note
   [{:keys [var author created-at]}]
   [:div.recently-updated
-   (util/$avatar author)
+   (util/$avatar author {:size 48})
    [:span.content
     (:login author)
     " authored a note for "


### PR DESCRIPTION
Avatars are low quality in the Recently Updated section of the home page

<img width="269" height="245" alt="image" src="https://github.com/user-attachments/assets/959b4fd1-3b22-4004-94f0-b32a42339ae6" />

[$avatar](https://github.com/nubank/clojuredocs/blob/31d4bd2dc7b1d5d1950e2b5e5f204735331d885e/src/cljc/clojuredocs/util.cljc#L122) defaults to a 32px wide image when no size is provided, but the [.avatar](https://github.com/nubank/clojuredocs/blob/31d4bd2dc7b1d5d1950e2b5e5f204735331d885e/src/clj/clojuredocs/css.clj#L558) css set a 48px wide image. Resulting in low quality images in the home page.

This change sets the optional :size to 48 so that the images are generated at the correct size



