### PR TITLE
Add Clojure/Conj 2026 banner

### DIFF
--- a/src/clj/clojuredocs/css.clj
+++ b/src/clj/clojuredocs/css.clj
@@ -895,6 +895,17 @@
          :text-decoration 'underline
          :font-weight 600}
      [:&:hover {:color "rgba(255,255,255, 0.85)"}]]]
+   [:.conj-banner
+    {:text-align 'center
+     :background-color "rgb(68,138,88)"
+     :color "rgba(255,255,255, 0.95)"
+     :font-size "14px"
+     :font-weight 400
+     :padding "8px"}
+    [:a {:color "rgba(255,255,255, 1)"
+         :text-decoration 'underline
+         :font-weight 600}
+     [:&:hover {:color "rgba(255,255,255, 0.85)"}]]]
    [:.toggle-controls :.login-required-message
     {:text-align 'right
      :margin-bottom "4px"

--- a/src/clj/clojuredocs/pages/common.clj
+++ b/src/clj/clojuredocs/pages/common.clj
@@ -172,6 +172,12 @@
       (when config/staging-banner?
         [:div.staging-banner
          "This is the ClojureDocs staging site, where you'll find all the neat things we're working on."])
+      [:div.conj-banner
+       "Clojure/Conj 2026 — Charlotte, NC — Sept 30 - Oct 2 "
+       [:a {:href "https://2026.clojure-conj.org/"
+            :target "_blank"
+            :onclick "_paq.push(['trackEvent', 'Banner', 'Click', 'Conj 2026']);"}
+        "Learn More & Get Tickets →"]]
       [:div.desktop-nav-bar
        ($navbar opts)]
       [:div


### PR DESCRIPTION
## Summary

Adds a site-wide banner promoting [Clojure/Conj 2026](https://2026.clojure-conj.org/) (Charlotte, NC — Sept 30 – Oct 2).

Closes #26

## Changes

- **`css.clj`** — Added `.conj-banner` style (green background, white text, underlined link with hover), following the same pattern as [@JarrodCTaylor's survey banner](https://github.com/zk/clojuredocs/commit/bed3f8067093d5fe62dcf9f7ce3c2cfa874de2fb)
- **`common.clj`** — Added the banner div between the staging banner and the desktop nav bar, same placement as the survey banner
- **Matomo click tracking** — The banner link fires a `trackEvent('Banner', 'Click', 'Conj 2026')` event via the existing Matomo `_paq` integration, so we can monitor engagement in the Matomo dashboard without any additional dependencies

## To remove after the event

Delete the `[:div.conj-banner ...]` block from `common.clj`. The `.conj-banner` CSS can be left or removed at that time.

---

> **AI Disclosure:** This PR was pair-programmed by @lambduhh with GitHub Copilot (Claude Opus 4.6). The human identified the issue, selected the implementation pattern (Jarrod's survey banner commit), reviewed all changes, and decided to add Matomo tracking. The AI applied the pattern, wrote the CSS/HTML, and drafted this PR description.
