### PR TITLE
Add UTM tracking to Conj 2026 banner link

### DIFF
--- a/src/clj/clojuredocs/pages/common.clj
+++ b/src/clj/clojuredocs/pages/common.clj
@@ -174,7 +174,7 @@
          "This is the ClojureDocs staging site, where you'll find all the neat things we're working on."])
       [:div.conj-banner
        "Clojure/Conj 2026 — Charlotte, NC — Sept 30 - Oct 2 "
-       [:a {:href "https://2026.clojure-conj.org/"
+       [:a {:href "https://2026.clojure-conj.org/?utm_source=clojuredocs&utm_medium=banner&utm_campaign=conj2026"
             :target "_blank"
             :onclick "_paq.push(['trackEvent', 'Banner', 'Click', 'Conj 2026']);"}
         "Learn More & Get Tickets →"]]


### PR DESCRIPTION
## Summary

Adds UTM tracking parameters to the Conj 2026 banner link so the Conj site's own analytics can attribute traffic from ClojureDocs.

Follow-up to #33.

## Changes

- **`common.clj`** — Added `utm_source=clojuredocs&utm_medium=banner&utm_campaign=conj2026` to the banner URL

## Deploy note

Requires app restart (`sudo systemctl restart clojuredocs`) since the HTML is server-rendered.

---

> **AI Disclosure:** This PR was pair-programmed by @lambduhh with GitHub Copilot (Claude Opus 4.6). The human's manager suggested adding UTM parameters for cross-site attribution. The AI applied the change and drafted this PR description.
