### PR TITLE
Schedule export JSON regeneration every 6 hours

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,41 @@ Document design and architecture decisions. Lightweight alternative to full ADRs
 
 ---
 
+## 2026-05-11 — Schedule export JSON regeneration in-process
+
+### Status
+Decided
+
+### Context
+- `clojuredocs-export.json` is consumed by editor plugins (Calva, CIDER, etc.) to show usage examples inline. It was only regenerated manually via `lein run -m clojuredocs.export`.
+- The file went stale — vars like `halt-when` had `null` examples in the JSON despite having examples on the website. A community member reported the issue in Slack.
+- Issue #38 was created to automate regeneration.
+
+### Decision
+- Use `java.util.concurrent.ScheduledExecutorService` in `start-app` to run `export/run-export` every 6 hours, starting immediately on server boot.
+
+### Rationale
+- In-process scheduling reuses the existing DB connection and data access layer — no cold-start JVM, no separate env config.
+- Zero new dependencies; `ScheduledExecutorService` is a JVM primitive.
+- Initial delay of 0 means every deploy immediately refreshes the export.
+- Scales through the planned redesign: as the data model changes (multi-library, dialect metadata, quality signals), the export function evolves with it and the scheduler is indifferent.
+
+### Alternatives Considered
+- Cron job on the server (`lein run -m clojuredocs.export`) — spins up a separate JVM each time, requires MongoDB URL in cron environment, loses access to shared caches and connection pools.
+- External scheduler (e.g., systemd timer) — adds infrastructure dependency and deployment complexity for a simple periodic task.
+
+### Impacts and Risks
+- Export runs on a dedicated single-thread executor, so at most one export runs at a time.
+- Risk: a long-running export could overlap with the next scheduled run. Mitigation: `scheduleAtFixedRate` skips if the previous run hasn't finished; export currently takes seconds.
+- Risk: export failure kills the scheduler thread. Mitigation: `run-scheduled-export` wraps the call in try/catch.
+
+### Links
+- [Issue #38](https://github.com/nubank/clojuredocs/issues/38)
+- [src/clj/clojuredocs/export.clj](src/clj/clojuredocs/export.clj)
+- [src/clj/clojuredocs/main.clj](src/clj/clojuredocs/main.clj)
+
+---
+
 ## 2026-04-28 — Defer jank dialect until stable var enumeration exists
 
 ### Status

--- a/src/clj/clojuredocs/main.clj
+++ b/src/clj/clojuredocs/main.clj
@@ -3,9 +3,11 @@
             [somnium.congomongo :as mon]
             [clojuredocs.env :as env]
             [clojuredocs.entry :as entry]
+            [clojuredocs.export :as export]
             [clojuredocs.config :as config]
             [clojuredocs.css :as css]
-            [garden.core :as garden]))
+            [garden.core :as garden])
+  (:import [java.util.concurrent Executors TimeUnit]))
 
 (defn compile-css []
   (garden/css
@@ -78,6 +80,17 @@
 
   (add-indexes-to-coll! :migrate-users [:email :migraion-key]))
 
+(def ^:private export-path "resources/public/clojuredocs-export.json")
+
+(def ^:private export-interval-hours 6)
+
+(defn- run-scheduled-export []
+  (try
+    (export/run-export export-path)
+    (println "Export updated:" export-path)
+    (catch Exception e
+      (println "Scheduled export failed:" (.getMessage e)))))
+
 (defn start-app []
   (compile-css)
   (let [{:keys [mongo-url port entry] :as app} (create-app)
@@ -86,9 +99,15 @@
     (mon/set-connection! mongo-conn)
     (add-all-indexes!)
     (let [stop-server (start-http-server entry
-                        {:port port :join? false})]
+                        {:port port :join? false})
+          executor (Executors/newSingleThreadScheduledExecutor)]
+      (.scheduleAtFixedRate executor
+        ^Runnable run-scheduled-export
+        0 export-interval-hours TimeUnit/HOURS)
       (println (format "Server running on port %d" port))
+      (println (format "Export scheduled every %d hours" export-interval-hours))
       (fn []
+        (.shutdown executor)
         (mon/close-connection mongo-conn)
         (.stop stop-server)))))
 


### PR DESCRIPTION
Closes #38

## Problem

`clojuredocs-export.json` — consumed by editor plugins (Calva, CIDER, etc.) to show usage examples inline — was only regenerated manually via `lein run -m clojuredocs.export`. It went stale: vars like `halt-when` had `null` examples in the JSON despite having examples on the website.

## Solution

Add an in-process `ScheduledExecutorService` in `start-app` that runs `export/run-export` every 6 hours, starting immediately on server boot.

- Zero new dependencies — `ScheduledExecutorService` is a JVM primitive
- Reuses the existing DB connection (no cold-start JVM like a cron job would need)
- Initial delay of 0 means every deploy immediately refreshes the export
- Export failure is caught so it never kills the scheduler thread
- Executor is shut down cleanly in the stop function

## Changes

- **`main.clj`**: Added `clojuredocs.export` require, `java.util.concurrent` imports, `run-scheduled-export` wrapper with error handling, and wired the scheduler into `start-app`/stop lifecycle
- **`decisions.md`**: Added decision log entry documenting the choice of in-process scheduling over cron