### PR TITLE
Hide implementation vars from search and namespace pages

### DIFF
--- a/src/clj/clojuredocs/css.clj
+++ b/src/clj/clojuredocs/css.clj
@@ -313,7 +313,27 @@
       :transition "opacity 0.2s ease"}
      [:&.unsupported
       {:opacity 0.15
-       :filter "grayscale(100%)"}]]]])
+       :filter "grayscale(100%)"}]]]
+   [:.implementation-badge
+    {:display 'inline-block
+     :margin-top "5px"
+     :padding "2px 8px"
+     :font-size "11px"
+     :font-weight 'bold
+     :color "#856404"
+     :background-color "#fff3cd"
+     :border "1px solid #ffc107"
+     :border-radius "10px"}]
+   [:.implementation-notice
+    {:margin-bottom "15px"
+     :padding "10px 15px"
+     :font-size "13px"
+     :color "#856404"
+     :background-color "#fff3cd"
+     :border "1px solid #ffeaa0"
+     :border-radius "4px"}]
+   [:&.implementation-var
+    [:.var-name {:opacity 0.7}]]])
 
 (def quickref
   [[:.toc {:margin-bottom "20px"}

--- a/src/clj/clojuredocs/pages/nss.clj
+++ b/src/clj/clojuredocs/pages/nss.clj
@@ -18,7 +18,8 @@
 (defn vars-for [ns]
   (->> search/clojure-lib
        :vars
-       (filter #(= ns (:ns %)))))
+       (filter #(= ns (:ns %)))
+       (remove search/impl-var?)))
 
 (defn group-vars [vars]
   (->> vars

--- a/src/clj/clojuredocs/pages/vars.clj
+++ b/src/clj/clojuredocs/pages/vars.clj
@@ -159,6 +159,16 @@
               :class (str "dialect-badge"
                           (when-not supported? " unsupported"))}])]))
 
+(defn $implementation-badge [v]
+  (when (search/impl-var? v)
+    [:span.implementation-badge "Implementation detail"]))
+
+(defn $implementation-notice [v]
+  (when (search/impl-var? v)
+    [:div.implementation-notice
+     "This var is an implementation detail and is not part of the public API. "
+     "It may change or be removed without notice."]))
+
 (defn $var-header [{:keys [ns name added arglists forms] :as v}]
   [:div.row.var-header
    [:div.col-sm-8
@@ -173,7 +183,8 @@
         " ("
         [:a {:href su} "source"]
         ") "])
-     ($dialect-badges ns name)]]
+     ($dialect-badges ns name)
+     ($implementation-badge v)]]
    [:div.col-sm-12
     [:section
      [:ul.arglists
@@ -219,7 +230,9 @@
                             (take 4)))
            :body
            (common/$main
-             {:body-class "var-page"
+             {:body-class (if (search/impl-var? v)
+                            "var-page implementation-var"
+                            "var-page")
               :title (util/html-encode (str name " - " ns " | ClojureDocs - Community-Powered Clojure Documentation and Examples"))
               :meta {"description" og-description
                      "twitter:card" "summary"
@@ -272,6 +285,7 @@
                            (common/$library-nav library ns)]]
                          [:div.col-sm-10
                           ($var-header v)
+                          ($implementation-notice v)
                           [:section
                            [:div.docstring
                             (if doc

--- a/src/clj/clojuredocs/search.clj
+++ b/src/clj/clojuredocs/search.clj
@@ -33,7 +33,16 @@
      :forms ; -> list of strings
      :deprecated
      :url
-     :no-doc])
+     :no-doc
+     :skip-wiki])
+
+(defn impl-var?
+  "Returns true if a var is an implementation detail — either marked
+   ^:skip-wiki or lacking a docstring (the same heuristic Clojure's
+   official docs use to omit internal vars)."
+  [{:keys [skip-wiki doc special-form]}]
+  (and (not special-form)
+       (or skip-wiki (nil? doc))))
 
 (defn cond-update-in [m keys & rest]
   (if (get-in m keys)
@@ -111,6 +120,7 @@
 (def searchable-vars
   (->> clojure-lib
        :vars
+       (remove impl-var?)
        (map #(assoc % :keywords (tokenize-name (:name %))))))
 
 (def searchable-nss
@@ -136,7 +146,8 @@
     (clucy/add search-index page)))
 
 (def lookup-vars
-  (->> searchable-vars
+  (->> clojure-lib
+       :vars
        (reduce #(assoc %1 (str (:ns %2) "/" (:name %2)) %2) {})))
 
 (defn lookup [ns-name]


### PR DESCRIPTION
Vars marked ^:skip-wiki or lacking a docstring are implementation details that the official Clojure docs omit. ClojureDocs now does the same: hidden from search and namespace listings, but still accessible via direct URL with an amber Implementation detail badge, yellow notice banner, and dimmed var name.

Closes nubank/clojuredocs#42