### PR TITLE
Fix case-insensitive search for vars with uppercase names

### DIFF
--- a/src/clj/clojuredocs/search.clj
+++ b/src/clj/clojuredocs/search.clj
@@ -121,7 +121,7 @@
   (->> clojure-lib
        :vars
        (remove impl-var?)
-       (map #(assoc % :keywords (tokenize-name (:name %))))))
+       (map #(assoc % :keywords (str/lower-case (tokenize-name (:name %)))))))
 
 (def searchable-nss
   (->> static/clojure-namespaces
@@ -202,6 +202,7 @@ Still maintains the O(n*m) guarantee.
 (defn format-query [q]
   (some-> q
     str/trim
+    str/lower-case
     drop-leading-stars
     lucene-escape
     (str "*")))


### PR DESCRIPTION
## Problem

`clojure.core/Throwable->map` (and any var with uppercase characters) can't be found via search, even though it has a page and appears in the vars list.

## Root Cause

The search index is built with `WhitespaceAnalyzer` (case-preserving), so `Throwable->map` is stored with a capital T. But `clucy/search` is called without that analyzer binding, falling back to clucy's default `StandardAnalyzer`. In Lucene 4.2.0, `QueryParser` lowercases wildcard terms by default. The query becomes `throwable->map*` but the index has `Throwable->map` — case mismatch, no results.

This is narrow because almost every Clojure core var is all-lowercase, which is why it went unnoticed.

## Fix

Two lines of `str/lower-case`:

1. **Index side**: Lowercase the `keywords` field when building `searchable-vars` — index tokens are stored lowercase
2. **Query side**: Lowercase the query string in `format-query` — queries are normalized to match

This makes search case-insensitive by construction, independent of Lucene's analyzer behavior.

Closes #44