### PR TITLE
fix: correct typo :migraion-key -> :migration-key in add-all-indexes!

### DIFF
--- a/src/clj/clojuredocs/main.clj
+++ b/src/clj/clojuredocs/main.clj
@@ -78,7 +78,7 @@
 
   (add-indexes-to-coll! :users [:login :account-source])
 
-  (add-indexes-to-coll! :migrate-users [:email :migraion-key]))
+  (add-indexes-to-coll! :migrate-users [:email :migration-key]))
 
 (def ^:private export-path "resources/public/clojuredocs-export.json")
 


### PR DESCRIPTION
## Summary
Fix typo in index key in `main.clj`: `:migraion-key` → `:migration-key` in the `add-all-indexes!` call for the `:migrate-users` collection.

## Bug
The key `:migraion-key` is missing a 't' — it should be `:migration-key`.

Per issue #56 reported by @TelepathicGrunt.

## Changes
- `src/clj/clojuredocs/main.clj` line 81: `:migraion-key` → `:migration-key`