### PR TITLE
fix: use coll parameter in add-indexes-to-coll! (issue #53)

### DIFF
--- a/src/clj/clojuredocs/main.clj
+++ b/src/clj/clojuredocs/main.clj
@@ -51,7 +51,7 @@
 
 (defn add-indexes-to-coll! [coll ks]
   (doseq [k ks]
-    (mon/add-index! :examples [k])))
+    (mon/add-index! coll [k])))
 
 (defn add-all-indexes! []
   (add-indexes-to-coll!


### PR DESCRIPTION
## Summary

Fixes #53 — `add-indexes-to-coll!` ignores its `coll` parameter; all indexes were created on `:examples` instead of the intended collection.

## Changes

- `src/clj/clojuredocs/main.clj`: Changed `(mon/add-index! :examples [k])` → `(mon/add-index! coll [k])`
- 1 file, 1 line changed

## Verification

Before: all indexes created on `:examples` regardless of collection argument
After: each collection receives its intended indexes (`:namespaces`, `:see-alsos`, `:libraries`, `:notes`, `:legacy-var-redirects`, `:users`, `:migrate-users`)

Fixes #53