### PR TITLE
chore: add GitHub issue/PR templates and docs structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report incorrect behavior on clojuredocs.org or in the codebase
+labels: bug
+---
+
+## Problem
+
+<!-- What is wrong? Lead with the user-visible effect, then the consequence. -->
+
+## Steps to Reproduce
+
+<!--
+Numbered steps a maintainer can follow in a fresh browser session.
+Include URLs, var names, console output as relevant.
+-->
+
+1.
+2.
+3. **Observed:** ...
+4. **Expected:** ...
+
+## Context
+
+<!--
+Established facts, code paths, prior discussion, related issues.
+Link to specific files or clojuredocs.org pages where useful.
+-->
+
+## References
+
+<!-- Related issues (#N), repo file paths, external docs, clojuredocs.org pages. -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,28 @@
+---
+name: Enhancement
+about: Suggest an improvement to an existing feature
+labels: enhancement
+---
+
+## Problem
+
+<!-- What is missing or insufficient, from a user's perspective? Why does it matter? -->
+
+## Demonstration
+
+<!--
+Concrete examples of the current gap.
+E.g. "Visit clojuredocs.org/clojure.core/pmap — nothing on the page indicates
+that pmap does not exist in ClojureScript."
+-->
+
+## Context
+
+<!--
+Established facts, code paths, prior discussion, related issues.
+Link to specific files or clojuredocs.org pages where useful.
+-->
+
+## References
+
+<!-- Related issues (#N), repo file paths, external docs, clojuredocs.org pages. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Propose a new capability for clojuredocs.org
+labels: feature
+---
+
+## Problem
+
+<!-- What problem does this solve? Who encounters it and why is it worth solving? -->
+
+## Demonstration
+
+<!--
+Concrete examples of the gap today.
+Show what the user sees (or doesn't see) that motivates the request.
+-->
+
+## Context
+
+<!--
+Established facts, prior discussion, related issues.
+Link to specific files or clojuredocs.org pages where useful.
+-->
+
+## References
+
+<!-- Related issues (#N), repo file paths, external docs, clojuredocs.org pages. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Context
+
+<!-- What triggered this change? Link the issue if there is one. -->
+
+## Problem
+
+<!-- What is broken, missing, or insufficient? -->
+
+## Solution
+
+<!-- What does this change do? Highlight rationale only for non-obvious decisions. -->
+
+---
+
+<details>
+<summary>Father Watson Questions (diagnostic framing)</summary>
+
+### What do we know?
+
+<!-- Established facts. Evidence, code references, prior conversation. -->
+
+### What do we need to know?
+
+<!-- Open questions. Investigations not yet done. Decisions deferred to maintainers. -->
+
+### Where are we?
+
+<!-- Current state. The baseline before this change. -->
+
+### Where are we going?
+
+<!-- Desired outcomes, in user-facing terms. -->
+
+</details>

--- a/.github/skills/issue-writer/SKILL.md
+++ b/.github/skills/issue-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-writer
-description: 'Draft GitHub issues for nubank/clojuredocs using the Father Watson framing format. Use when filing bugs, enhancements, or feature requests. Use when turning Slack threads, conversation context, feature proposals, or bug reports into well-structured issues.'
+description: 'Draft GitHub issues for nubank/clojuredocs. Use when filing bugs, enhancements, or feature requests. Use when turning Slack threads, conversation context, feature proposals, or bug reports into well-structured issues.'
 ---
 
 # Issue Writer
@@ -17,9 +17,11 @@ Draft GitHub issues for [nubank/clojuredocs](https://github.com/nubank/clojuredo
 
 1. **Classify.** Determine the issue type (bug, enhancement, feature). Ask one clarifying question only if the type or user-facing impact is genuinely ambiguous.
 2. **Verify.** If the user mentions a URL or file path, fetch or read it to confirm the claim before drafting.
-3. **Read the format guide.** Load [docs/ai/issue-writing-guide.md](../../../docs/ai/issue-writing-guide.md) for the full template, section guidance, and example.
-4. **Draft.** Write the issue in the format specified by the guide. Title as H1, then Problem, Demonstration, Father Watson Questions, optional Assumptions, and References.
+3. **Pick the template.** Use the matching [issue template](../../ISSUE_TEMPLATE/) (bug, enhancement, or feature). Load [docs/github-templates/issue-writing-guide.md](../../../docs/github-templates/issue-writing-guide.md) for section guidance and examples.
+4. **Draft.** Write the issue following the template structure: Problem, Demonstration/Steps to Reproduce, Context, and References. Omit sections that don't apply.
 5. **Deliver.** Present the draft in chat. Save as a `.md` file only if the user asks to commit it.
+
+Note: Father Watson diagnostic questions (What do we know? What do we need to know? Where are we? Where are we going?) belong in the [PR description template](../../pull_request_template.md), not in issues.
 
 ## Key constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,14 +113,26 @@ Reviewed-by: Jordan Miller <jordan.miller@nubank.com.br>
 
 ### Titles
 
-Use conventional-commit prefixes: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`.
+Use conventional-commit prefixes: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`. Keep titles under ~70 characters; details go in the body.
 
 ### Body
 
-Keep it direct:
+Four sections, in this order:
+
 1. **Context.** What triggered the change. Link the issue if there is one.
-2. **Problem.** What is broken, missing, or insufficient.
-3. **Solution.** What the change does.
+2. **Problem.** What is broken, missing, or insufficient today.
+3. **Solution.** What the change does. Highlight rationale only for non-obvious decisions.
+4. **Father Watson Questions.** In a collapsible `<details>` block. What do we know, what do we need to know, where are we, where are we going. Use when the change involves open questions or diagnostic framing.
+
+Tone: direct and assertive. Short and specific.
+
+Don't:
+
+- Use marketing language ("comprehensive", "robust", "production-ready").
+- Restate the diff line by line — the reviewer can read it.
+- Pad a simple change with paragraphs. If you need walls of text to describe one decision, the decision isn't clear yet.
+
+See the [PR template](.github/pull_request_template.md) for the standard body skeleton.
 
 ## Docs conventions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Documentation
+
+Doc map for [nubank/clojuredocs](https://github.com/nubank/clojuredocs).
+
+## Project
+
+| Doc | Description |
+|---|---|
+| [2026 Vision](2026vison.md) | Vision statement and redesign direction |
+| [Glossary](glossary.md) | Domain terms and definitions |
+| [Decisions](decisions.md) | Decision log — design and architecture choices |
+| [Library Layers](lib-layers.md) | Dependency layers of the codebase |
+
+## Development
+
+| Doc | Description |
+|---|---|
+| [Dev Setup](dev-setup.md) | Environment setup for local development |
+| [Dev Setup (VS Code)](dev-setup-vscode.md) | VS Code-specific setup notes |
+| [Release Protocol](release-protocol.md) | How to deploy and release |
+
+## GitHub Templates
+
+| Doc | Description |
+|---|---|
+| [GitHub Templates](github-templates/) | Issue templates, PR template, and conventions |
+| [Issue Writing Guide](github-templates/issue-writing-guide.md) | How to write well-structured issues |
+
+## Research
+
+| Doc | Description |
+|---|---|
+| [Dialect Compatibility Planning](research/issue-30-dialect-compat-planning.md) | Planning doc for cross-dialect indicators (#30) |
+| [Data Model Coupling Audit](research/data-model-coupling-audit.md) | Audit of data model dependencies |
+| [Dialect Prompt](research/30-dialect-prompt.md) | Prompt for dialect compatibility research |

--- a/docs/github-templates/README.md
+++ b/docs/github-templates/README.md
@@ -1,0 +1,23 @@
+# GitHub Templates
+
+Templates and conventions for issues and pull requests in [nubank/clojuredocs](https://github.com/nubank/clojuredocs).
+
+## Issue templates
+
+GitHub offers these templates when creating a new issue via `.github/ISSUE_TEMPLATE/`:
+
+| Template | Use when |
+|---|---|
+| [Bug report](../../.github/ISSUE_TEMPLATE/bug.md) | Reporting incorrect behavior on clojuredocs.org or in the codebase |
+| [Enhancement](../../.github/ISSUE_TEMPLATE/enhancement.md) | Suggesting an improvement to an existing feature |
+| [Feature request](../../.github/ISSUE_TEMPLATE/feature.md) | Proposing a new capability |
+
+## PR template
+
+The [pull request template](../../.github/pull_request_template.md) provides the standard body structure: Context, Problem, Solution, plus Father Watson diagnostic questions in a collapsible section.
+
+## Conventions
+
+- [Issue writing guide](issue-writing-guide.md) — detailed section guidance, principles, and examples for writing issues
+- [PR conventions](../../CLAUDE.md#pr-conventions) — title prefixes and body format (in CLAUDE.md)
+- [Docs conventions](../../CLAUDE.md#docs-conventions) — linking, glossary, and diagram rules (in CLAUDE.md)

--- a/docs/github-templates/issue-writing-guide.md
+++ b/docs/github-templates/issue-writing-guide.md
@@ -8,7 +8,7 @@ This guide describes the format conventions used in this repo's issue tracker. I
 
 Copy the **Prompt** section below into any AI assistant (ChatGPT, Claude, Copilot, etc.) as a system prompt or paste it at the start of a conversation. Then give it a rough description of a bug or feature idea — a Slack thread, a conversation summary, a one-liner — and it will produce an issue formatted for this repo.
 
-If you use VS Code with GitHub Copilot, this guide is also available as a [skill](.github/skills/issue-writer/SKILL.md) that can be invoked with `/issue-writer` or loaded automatically when the agent detects a relevant context.
+If you use VS Code with GitHub Copilot, this guide is also available as a [skill](../../.github/skills/issue-writer/SKILL.md) that can be invoked with `/issue-writer` or loaded automatically when the agent detects a relevant context.
 
 <details>
 <summary><strong>Prompt</strong> (click to expand)</summary>
@@ -26,7 +26,7 @@ Rules:
 - No "Acceptance Criteria", "Risks & Mitigations", or "Implementation Steps" sections.
 - Omit sections that don't apply. Don't pad.
 
-Format:
+Format: Use the matching GitHub issue template (.github/ISSUE_TEMPLATE/).
 
 # <Title — short, descriptive>
 
@@ -38,21 +38,8 @@ Format:
 ## Demonstration (or "Steps to Reproduce" for bugs)
 Numbered steps with URLs, var names, console output as relevant.
 
-## Father Watson Questions
-
-**What do we know?**
-- Bullet established facts, code paths, prior discussion.
-
-**What do we need to know?**
-- Bullet open questions that would unblock a decision.
-
-**Where are we?**
-- Current state of the relevant code or feature.
-
-**Where are we going?**
-- Desired outcomes in user-facing terms, not implementation details.
-
-## Assumptions (optional, only if load-bearing)
+## Context
+Established facts, code paths, prior discussion, related issues.
 
 ## References
 - Related issues (#N), repo file paths, external docs, clojuredocs.org pages.
@@ -73,7 +60,9 @@ Numbered steps with URLs, var names, console output as relevant.
 
 ## Issue template
 
-Use this skeleton, omitting sections that don't apply:
+Use the matching [GitHub issue template](../../.github/ISSUE_TEMPLATE/) for the issue type (bug, enhancement, or feature). The templates live in `.github/ISSUE_TEMPLATE/` and GitHub will offer them when creating a new issue.
+
+The general skeleton, omitting sections that don't apply:
 
 ```markdown
 # <Issue title — short, descriptive, no clickbait>
@@ -94,28 +83,10 @@ as the section name. Include URLs, exact var names, console output, screenshots 
 2. <step>
 3. <observed result>
 
-## Father Watson Questions
+## Context
 
-**What do we know?**
-<Bullet the established facts. Behavior observed, code paths involved, prior discussion,
+<Established facts. Behavior observed, code paths involved, prior discussion,
 related issues. Cite specific files or links where you can.>
-
-**What do we need to know?**
-<Bullet the open questions. What information would unblock a decision? What hasn't been
-investigated yet? What would a maintainer reasonably need to ask before triaging this?>
-
-**Where are we?**
-<The current state of the relevant code or feature. What exists today, what's already
-in place, what the user-facing behavior is right now.>
-
-**Where are we going?**
-<The desired end state, framed as outcomes rather than implementation. What would success
-look like for the user? What invariants should hold afterward?>
-
-## Assumptions (optional)
-
-<Only include if there are non-obvious assumptions baked into the framing of the issue.
-Skip this section entirely if there's nothing to flag.>
 
 ## References
 
@@ -123,6 +94,8 @@ Skip this section entirely if there's nothing to flag.>
 - <link to relevant file path in the repo>
 - <link to external docs, cheatsheets, or specs>
 ```
+
+> **Note:** Father Watson diagnostic questions (What do we know? What do we need to know? Where are we? Where are we going?) have moved to the [PR description template](../../.github/pull_request_template.md). Issues diagnose; PRs frame the solution.
 
 ## Section guidance
 
@@ -150,18 +123,11 @@ For **features and enhancements**: concrete examples of the current gap. E.g. "V
 
 ### Father Watson Questions
 
-These four questions replace the "Proposed Solution / Implementation Steps / Acceptance Criteria" pattern. They keep the issue in the **diagnostic phase** rather than jumping to design.
+> Father Watson diagnostic questions have moved to the [PR description template](../../.github/pull_request_template.md). Issues use a simpler **Context** section instead.
 
-- **What do we know?** — Established facts. Evidence, code references, prior conversation.
-- **What do we need to know?** — Open questions. Investigations not yet done. Decisions deferred to maintainers.
-- **Where are we?** — Current state. The baseline. Different from "what do we know" — this is the snapshot, not the inventory of facts.
-- **Where are we going?** — Desired outcomes, in user-facing terms. Not "add a function called X" but "users can tell at a glance whether a var works in their dialect."
+### Context
 
-Use bullet points under each question. Keep each bullet to a single idea. If a question doesn't apply, write a single sentence explaining why rather than padding.
-
-### Assumptions
-
-Only include if there's a load-bearing assumption that, if false, would change the framing of the issue. E.g. "Assumes the runtime-var-access constraint from #5 still holds." Skip otherwise — empty Assumptions sections are noise.
+Established facts relevant to the issue: behavior observed, code paths involved, prior discussion, related issues. Cite specific files or links where you can. This replaces the four Father Watson questions — keep it factual and concise.
 
 ### References
 


### PR DESCRIPTION
- .github/ISSUE_TEMPLATE/: bug, enhancement, feature templates inspired by clojure.org/dev/creating_tickets — simple Problem/Demonstration/Context/References structure
- .github/pull_request_template.md: Context/Problem/Solution with Father Watson diagnostic questions in a collapsible details block
- docs/README.md: doc map index (design-spec pattern)
- docs/github-templates/README.md: templates sub-index
- Move docs/ai/issue-writing-guide.md to docs/github-templates/
- Update CLAUDE.md PR conventions (title length, tone, don'ts)
- Update issue-writer skill to reference new paths

Father Watson questions moved from issues (where they added overhead) to PR descriptions (where diagnostic framing helps reviewers).