### PR TITLE
feat: adopt OKF + RDF-aligned YAML frontmatter for doc metadata

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,8 +4,8 @@ Project conventions are defined in [CLAUDE.md](../CLAUDE.md) at the repo root. T
 
 Key points:
 
-- **AI metadata**: Every prose doc under `docs/` needs an inline metadata block (see CLAUDE.md for format)
-- **Review maturity**: Use L0–L4 levels to indicate how much human review has occurred
+- **AI metadata**: Every prose doc under `docs/` needs a YAML frontmatter block ([OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)-conformant: required `type`) with field semantics aligned to Dublin Core Terms + PROV-O (see CLAUDE.md for the format and [docs/rfcs/okf-metadata-rfc.md](../docs/rfcs/okf-metadata-rfc.md) for rationale)
+- **Review maturity**: Use the `review_maturity` frontmatter key (L0–L4) to indicate how much human review has occurred
 - **Unverified claims**: Mark with `[unverified]` inline
 - **PRs**: Use conventional-commit prefixes (`feat:`, `fix:`, `docs:`, etc.)
 - **Code reviews**: Follow Clojure-specific review guidance in CLAUDE.md — flag behavior changes without tests, lazy seqs escaping resource scopes, silent nil swallowing; skip style preferences

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,21 +34,50 @@ See [docs/dev-setup.md](docs/dev-setup.md) for full setup.
 
 ## AI metadata on documents
 
-Every prose document under `docs/` must carry an inline metadata block at the top — before the first heading content — using this format:
+Every prose Markdown document under `docs/` must carry a **YAML frontmatter block** at the very top of the file — before any heading — delimited by `---`. This format is conformant with the [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md): the one hard requirement is a non-empty `type` field. Field *names and semantics* align with established RDF vocabularies — [Dublin Core Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/) (`dcterms:`) and [W3C PROV-O](https://www.w3.org/TR/prov-o/) (`prov:`) — so the same frontmatter is liftable to RDF triples without changing how it reads.
 
-```markdown
-> **Document metadata**
-> - **Created:** YYYY-MM-DD
-> - **Last updated:** YYYY-MM-DD
-> - **Tags:** comma, separated, tags
-> - **AI-assisted:** Yes — model + interface (e.g. "Claude Opus 4.6 via GitHub Copilot")
-> - **Session:** `session-id` (from debug log or Copilot session)
-> - **Tools:** MCP servers and capabilities available (e.g. "GitHub MCP, workspace files")
-> - **Agents/skills:** links to agent or skill definitions applied
-> - **Review maturity:** L0–L4 level + short description
->
-> _AI-assisted document. [Scope-specific disclaimer about what to verify.]_
+```yaml
+---
+type: RFC                              # REQUIRED (OKF) — dcterms:type. From the taxonomy below.
+title: Entity-Attribute Model EDN Schema        # dcterms:title
+description: One-line summary used by indexes, search, and previews.   # dcterms:description
+tags: [entity-model, edn-schema, issue-43]       # dcterms:subject
+created: 2026-06-09                    # dcterms:created (ISO 8601 date)
+modified: 2026-06-09                   # dcterms:modified (was "Last updated")
+source: https://github.com/nubank/clojuredocs/issues/43   # dcterms:source / OKF resource, when one exists
+# --- provenance (PROV-O) ---
+ai_assisted: "Claude Opus 4.8 via Claude Code"   # the prov:SoftwareAgent; the doc prov:wasGeneratedBy its run. Omit when not AI-assisted.
+session: c6580eec                      # identifies the prov:Activity
+tools: [Calva REPL, MongoDB seed data, workspace files]   # prov:used
+agents_skills: []                      # permalinks to agent/skill definitions applied
+# --- review trust (extension; no OKF/RDF native equivalent) ---
+review_maturity: L3                    # machine-readable L0–L4 (see below)
+review_note: human-verified via REPL evaluation
+---
 ```
+
+**Required:** `type`. **Recommended:** `title`, `description`, `tags`, `created`, `modified`. **Provenance (when AI-assisted):** `ai_assisted`, `session`, `tools`, `agents_skills`. **Review trust:** `review_maturity`, `review_note`. Consumers must tolerate unknown fields and unknown `type` values (OKF §9). Scope/caveat disclaimers go in the **body** (an italic line under the H1, or a `> **Caveat:**` callout) — not in frontmatter.
+
+### Field → RDF vocabulary mapping
+
+| Frontmatter key | RDF term | Meaning |
+|---|---|---|
+| `type` | `dcterms:type` | Nature/genre of the doc (also OKF's one required field) |
+| `title` | `dcterms:title` | Name of the doc |
+| `description` | `dcterms:description` | One-line account |
+| `tags` | `dcterms:subject` | Topics |
+| `created` | `dcterms:created` | Date of creation |
+| `modified` | `dcterms:modified` | Date of last meaningful change |
+| `source` | `dcterms:source` / `prov:wasDerivedFrom` | Resource the doc derives from |
+| `ai_assisted` | `prov:wasAttributedTo` a `prov:SoftwareAgent` | The model/interface that generated the draft |
+| `tools` | `prov:used` | What the generating activity used |
+| `review_maturity` / `review_note` | extension; at L4 ≈ `dcterms:creator` / `prov:wasAttributedTo` a `prov:Person` | Human review trust |
+
+The optional [`docs/context.jsonld`](docs/context.jsonld) is the canonical JSON-LD `@context` mapping these keys to their `dcterms:`/`prov:` IRIs; it is out-of-band, so the doc files stay plain YAML you can `cat`.
+
+### `type` taxonomy
+
+`Reference`, `Guide`, `RFC`, `Decision Log`, `Errata`, `Data Model`, `Diagram`, `Research`, `Review`, `Vision`. Descriptive and extensible — add new values when needed; don't repurpose existing ones. (`type` ≡ `dcterms:type`; this list is our controlled vocabulary.)
 
 ### Review maturity levels
 
@@ -62,7 +91,7 @@ Review maturity levels use a progressive trust model, similar in spirit to [C2PA
 | **L3** | Human-verified | Human verified specific claims against primary sources (running system, database, upstream docs). |
 | **L4** | Human-endorsed | Human takes ownership. Content is treated as human-authored with AI assistance. |
 
-Use the level number in the metadata block: `**Review maturity:** L2 — human-reviewed via PR`.
+Use the level in the `review_maturity` frontmatter key (machine-readable), with a human-readable `review_note`: `review_maturity: L2` / `review_note: human-reviewed via PR`.
 
 ### Section-level review markers
 
@@ -94,6 +123,10 @@ This is the Markdown equivalent of Wikipedia's `[citation needed]` and C2PA's `r
 - **Agents/skills** — Permalink to the agent or skill definition files that were active. Different skills have different reliability profiles.
 - **Review maturity** — L0–L4 level. The level is a machine-readable prefix; the description after the dash is human-readable context.
 
+### OKF bundle root
+
+`docs/` is an OKF **bundle**. Its root [`docs/index.md`](docs/index.md) carries the only frontmatter an index file may have — `okf_version: "0.1"` — and lists the docs for progressive disclosure. `index.md` and `log.md` are OKF-reserved filenames; don't use them for content documents.
+
 ### Commit trailers
 
 ```
@@ -101,13 +134,16 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 Reviewed-by: Jordan Miller <jordan.miller@nubank.com.br>
 ```
 
-`Co-Authored-By` identifies the AI, following the GitHub convention for multi-author commits. `Reviewed-by` identifies the human who reviewed the diff before commit, following the Linux kernel convention for review attribution.
+`Co-Authored-By` identifies the AI, following the GitHub convention for multi-author commits. `Reviewed-by` identifies the human who reviewed the diff before commit, following the Linux kernel convention for review attribution. The `ai_assisted` frontmatter key (`prov:SoftwareAgent`) and the `Co-Authored-By` trailer carry the same fact in two places — keep them consistent.
 
 ### Rules
 
-- CSVs and data files don't need metadata blocks — only prose Markdown.
-- When updating a document, bump **Last updated** and adjust **Review maturity** if the review status changed.
-- This replaces lengthy per-session attribution logs. The commit message carries what was done; the document metadata carries the review status. No separate `docs/ai/` attribution files needed.
+- Applies to **prose Markdown under `docs/`**. Repo-root config (`README.md`, `CLAUDE.md`) and `.github/` templates are out of scope; `.github/ISSUE_TEMPLATE/*` carry their own GitHub-mandated frontmatter — don't touch it.
+- Data files (`*.edn`, `*.csv`) are not OKF concepts and need no frontmatter.
+- When updating a document, bump `modified` and adjust `review_maturity` if the review status changed.
+- Provenance is mandatory for AI-assisted docs. Citations to sources should be reproducible — commit-pinned GitHub permalinks for code, not branch names.
+- Cross-links between docs use repo-relative paths (e.g. `../glossary.md`) for GitHub navigability — a deliberate, OKF-permitted (§5.2) relative-link choice over OKF's `/`-rooted recommendation.
+- This replaces lengthy per-session attribution logs. The commit message carries what was done; the frontmatter carries provenance and review status. No separate `docs/ai/` attribution files needed.
 
 ## PR conventions
 

--- a/docs/2026vison.md
+++ b/docs/2026vison.md
@@ -1,3 +1,14 @@
+---
+type: Vision
+title: "ClojureDocs: Two-Year Vision (2026–2028)"
+description: Two-year vision and redesign direction for ClojureDocs.
+tags: [vision, redesign, roadmap]
+created: 2026-03-27
+modified: 2026-03-31
+review_maturity: L2
+review_note: Human-authored vision; frontmatter added during OKF migration.
+---
+
 # ClojureDocs: Two-Year Vision (2026–2028)
 
 > Make ClojureDocs the highest-signal, REPL-native, community-connected documentation system in the programming ecosystem.

--- a/docs/2026vison.md
+++ b/docs/2026vison.md
@@ -5,8 +5,9 @@ description: Two-year vision and redesign direction for ClojureDocs.
 tags: [vision, redesign, roadmap]
 created: 2026-03-27
 modified: 2026-03-31
-review_maturity: L2
-review_note: Human-authored vision; frontmatter added during OKF migration.
+creator: L. Jordan Miller
+review_maturity: L4
+review_note: Human-endorsed — author takes ownership of this vision.
 ---
 
 # ClojureDocs: Two-Year Vision (2026–2028)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,15 @@
+---
+type: Reference
+title: Documentation
+description: Documentation map for the nubank/clojuredocs repo.
+tags: [docs, index, navigation]
+created: 2026-06-09
+modified: 2026-06-09
+ai_assisted: "Claude Opus 4.6 via GitHub Copilot"
+review_maturity: L2
+review_note: Human-reviewed via PR.
+---
+
 # Documentation
 
 Doc map for [nubank/clojuredocs](https://github.com/nubank/clojuredocs).

--- a/docs/context.jsonld
+++ b/docs/context.jsonld
@@ -1,0 +1,26 @@
+{
+  "@context": {
+    "dcterms": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "schema": "http://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "type": "dcterms:type",
+    "title": "dcterms:title",
+    "description": "dcterms:description",
+    "tags": { "@id": "dcterms:subject", "@container": "@set" },
+    "created": { "@id": "dcterms:created", "@type": "xsd:date" },
+    "modified": { "@id": "dcterms:modified", "@type": "xsd:date" },
+    "source": { "@id": "dcterms:source", "@type": "@id" },
+    "creator": "dcterms:creator",
+    "contributors": { "@id": "dcterms:contributor", "@container": "@set" },
+
+    "ai_assisted": "prov:wasAttributedTo",
+    "session": "prov:wasGeneratedBy",
+    "tools": { "@id": "prov:used", "@container": "@set" },
+    "agents_skills": { "@id": "prov:used", "@container": "@set" },
+
+    "review_maturity": "schema:creativeWorkStatus",
+    "review_note": "dcterms:provenance"
+  }
+}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,9 +5,10 @@ description: Design and architecture decisions; lightweight alternative to full 
 tags: [decisions, architecture, living-document]
 created: 2026-04-29
 modified: 2026-06-16
+creator: L. Jordan Miller
 ai_assisted: "Claude Opus 4.8 via Claude Code"
-review_maturity: L2
-review_note: Decisions reflect the team's choices; rationale text AI-drafted from human direction.
+review_maturity: L4
+review_note: Human-endorsed — decisions are the team's; AI-drafted rationale is owned by the author.
 ---
 
 # Decision Log

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,6 +1,44 @@
+---
+type: Decision Log
+title: Decision Log
+description: Design and architecture decisions; lightweight alternative to full ADRs.
+tags: [decisions, architecture, living-document]
+created: 2026-04-29
+modified: 2026-06-16
+ai_assisted: "Claude Opus 4.8 via Claude Code"
+review_maturity: L2
+review_note: Decisions reflect the team's choices; rationale text AI-drafted from human direction.
+---
+
 # Decision Log
 
 Document design and architecture decisions. Lightweight alternative to full ADRs.
+
+---
+
+## 2026-06-16 — Adopt OKF + RDF-aligned YAML frontmatter for doc metadata
+
+### Status
+Decided
+
+### Context
+Document AI-provenance/review metadata was encoded as a Markdown blockquote (`> **Document metadata**`),
+which is human-readable but not machine-parseable and is non-conformant with the
+[Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+(no frontmatter, no required `type`).
+
+### Decision
+Replace the blockquote with YAML frontmatter conformant to OKF (required `type`), with field semantics aligned
+to [Dublin Core Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/) and
+[PROV-O](https://www.w3.org/TR/prov-o/). RDF stays additive via an optional JSON-LD context
+([docs/context.jsonld](context.jsonld)); the required surface remains pure OKF. The L0–L4 review-maturity
+model is retained as a queryable `review_maturity` field. See
+[RFC: OKF + RDF document metadata](rfcs/okf-metadata-rfc.md). A `bb` validator is a planned follow-up.
+
+### Consequences
+All prose docs under `docs/` migrate to frontmatter; `docs/` becomes an OKF bundle (`docs/index.md`). YAML
+frontmatter renders as a table on GitHub rather than the prior custom blockquote — accepted in exchange for
+machine-parseability.
 
 ---
 

--- a/docs/dev-setup-vscode.md
+++ b/docs/dev-setup-vscode.md
@@ -1,3 +1,14 @@
+---
+type: Guide
+title: VS Code + Calva
+description: Editor-specific setup notes for contributors using VS Code with Calva.
+tags: [dev-setup, vscode, calva]
+created: 2026-02-27
+modified: 2026-03-04
+review_maturity: L2
+review_note: Human-authored setup notes; frontmatter added during OKF migration.
+---
+
 # VS Code + Calva
 
 Editor-specific notes for contributors using VS Code with [Calva](https://calva.io/). See [dev-setup.md](dev-setup.md) for general environment setup (MongoDB, env vars, etc.).

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,3 +1,14 @@
+---
+type: Guide
+title: Dev Environment Setup
+description: Notes for getting a local development environment running.
+tags: [dev-setup, mongodb, leiningen]
+created: 2026-02-27
+modified: 2026-02-27
+review_maturity: L2
+review_note: Human-authored setup notes; frontmatter added during OKF migration.
+---
+
 # Dev Environment Setup
 
 Supplementary notes for getting a local development environment running. See also the [README](../README.md#dev) for the quick-start.

--- a/docs/github-templates/README.md
+++ b/docs/github-templates/README.md
@@ -1,3 +1,15 @@
+---
+type: Reference
+title: GitHub Templates
+description: Templates and conventions for issues and pull requests.
+tags: [github, templates, conventions]
+created: 2026-06-09
+modified: 2026-06-09
+ai_assisted: "Claude Opus 4.6 via GitHub Copilot"
+review_maturity: L2
+review_note: Human-reviewed via PR.
+---
+
 # GitHub Templates
 
 Templates and conventions for issues and pull requests in [nubank/clojuredocs](https://github.com/nubank/clojuredocs).

--- a/docs/github-templates/issue-writing-guide.md
+++ b/docs/github-templates/issue-writing-guide.md
@@ -1,3 +1,15 @@
+---
+type: Guide
+title: Issue Writing Guide
+description: How to write GitHub issues for this repo; doubles as an AI prompt.
+tags: [github, issues, guide, ai-prompt]
+created: 2026-06-09
+modified: 2026-06-09
+ai_assisted: "Claude Opus 4.6 via GitHub Copilot"
+review_maturity: L2
+review_note: Human-reviewed via PR.
+---
+
 # Issue Writing Guide
 
 How to write GitHub issues for [nubank/clojuredocs](https://github.com/nubank/clojuredocs).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,15 @@
+---
+type: Reference
+title: Glossary
+description: Domain terms as used in this codebase and design docs.
+tags: [glossary, domain-terms]
+created: 2026-03-04
+modified: 2026-03-04
+ai_assisted: "Claude Opus 4.6 (1M context) via Claude Code"
+review_maturity: L1
+review_note: AI-drafted research; see in-body disclaimer — claims not individually verified.
+---
+
 # Glossary
 
 > **AI Disclaimer**: This was researched and drafted using Claude Code powered by Claude Opus 4.6. AI-generated research contains false statements, unsupported assumptions, and missing context. Do not treat any claim as verified unless you have confirmed it against a primary source.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+---
+okf_version: "0.1"
+---
+
+# ClojureDocs Documentation Bundle
+
+Progressive-disclosure index for the `docs/` [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle. Each entry links a document and its one-line description. See [README.md](README.md) for the human landing page and [CLAUDE.md](../CLAUDE.md) for the metadata convention.
+
+# Project
+
+* [2026 Vision](2026vison.md) - Two-year vision and redesign direction.
+* [Glossary](glossary.md) - Domain terms scoped to this codebase.
+* [Documentation map](README.md) - Human landing page for the docs.
+
+# Conventions & process
+
+* [RFC: OKF + RDF document metadata](rfcs/okf-metadata-rfc.md) - Proposal to adopt OKF YAML frontmatter with RDF-aligned semantics.
+* [Decision Log](decisions.md) - Design and architecture decisions; lightweight ADRs.
+* [Release & Announcement Protocol](release-protocol.md) - Status-quo audit of the ship/announce process.
+* [GitHub Templates](github-templates/README.md) - Issue and PR templates and conventions.
+* [Issue Writing Guide](github-templates/issue-writing-guide.md) - How to write issues; doubles as an AI prompt.
+
+# Setup & architecture
+
+* [Dev Environment Setup](dev-setup.md) - Local development environment notes.
+* [VS Code + Calva](dev-setup-vscode.md) - Editor-specific setup for Calva users.
+* [Multi-Library :library-url chain](lib-layers.md) - How the `:library-url` property is resolved across layers.
+
+# Research
+
+* [Data Model Coupling Audit](research/data-model-coupling-audit.md) - Audit of data-model coupling in the current architecture.
+* [Cross-Dialect Compatibility Planning](research/issue-30-dialect-compat-planning.md) - Planning for Clojure/CLJS/babashka compatibility indicators (issue #30).
+* [Issue #30 Planning Prompt](research/30-dialect-prompt.md) - Claude Code prompt that generated the issue #30 planning doc.

--- a/docs/lib-layers.md
+++ b/docs/lib-layers.md
@@ -1,3 +1,14 @@
+---
+type: Diagram
+title: "Multi-Library :library-url Dependency Chain"
+description: How the :library-url property for each var is resolved across architecture layers.
+tags: [diagram, library-url, architecture]
+created: 2026-03-04
+modified: 2026-03-04
+review_maturity: L2
+review_note: Traced from source code; frontmatter added during OKF migration.
+---
+
 # Multi-Library :library-url Dependency Chain
 
 This diagram shows how the `:library-url` property for each var is handled in the current clojuredocs.org architecture. Each layer is labeled in ALL CAPS, with file references below.

--- a/docs/release-protocol.md
+++ b/docs/release-protocol.md
@@ -1,3 +1,14 @@
+---
+type: Reference
+title: Release & Announcement Protocol
+description: Status-quo audit of how we ship and announce changes.
+tags: [release, deploy, protocol, audit]
+created: 2026-03-13
+modified: 2026-03-18
+review_maturity: L1
+review_note: Status-quo audit; inherited infra not yet verified — see [goal] markers in body.
+---
+
 # Release & Announcement Protocol
 
 How we ship and communicate changes for the public Nubank fork of ClojureDocs.

--- a/docs/research/30-dialect-prompt.md
+++ b/docs/research/30-dialect-prompt.md
@@ -1,3 +1,14 @@
+---
+type: Research
+title: "Claude Code Prompt — Create Planning Template for Issue #30"
+description: The Claude Code prompt used to generate the issue #30 planning document.
+tags: [research, issue-30, prompt]
+created: 2026-04-29
+modified: 2026-04-29
+review_maturity: L2
+review_note: Human-authored prompt; frontmatter added during OKF migration.
+---
+
 # Claude Code Prompt — Create Planning Template for Issue #30
 
 > Paste into a Claude Code Opus 4.6 session in VS Code. You should be on the `nubank/clojuredocs` repo.

--- a/docs/research/data-model-coupling-audit.md
+++ b/docs/research/data-model-coupling-audit.md
@@ -1,3 +1,15 @@
+---
+type: Research
+title: Data Model Coupling Audit
+description: Audit of data-model coupling in the current clojuredocs architecture.
+tags: [research, data-model, coupling, audit]
+created: 2026-03-11
+modified: 2026-03-11
+ai_assisted: "Claude Opus 4.6 via GitHub Copilot"
+review_maturity: L1
+review_note: AI-drafted research; see in-body disclaimer — verify against the repo.
+---
+
 # Data Model Coupling Audit
 
 > **AI Disclaimer**: This research was conducted and drafted by Claude (Opus 4.6) via GitHub Copilot in VS Code. Trust nothing — AI-generated content may contain false statements. All code references should be verified against the repository at the time of reading.
@@ -12,7 +24,7 @@ Evaluate the accuracy of three candidate problem statements about the ClojureDoc
 
 ## Research Context
 
-- **Model**: Claude Opus 4.6 (via GitHub Copilot + Calva w Clojure MPC Server), applied "research-analyst" agent stolen from stu-ai-projects
+- **Model**: Claude Opus 4.6 (via GitHub Copilot + Calva w Clojure MCP Server), applied a "research-analyst" agent adapted from an internal agent definition
 - **Token-intensive context**: ~15 source files read across `src/clj/`, `src/cljs/`, and `src/cljc/` directories; ~3,500 lines of code inspected
 - **Search patterns used**: `schema.core|s/Str|s/Int|s/Any`, `:library-url`, `:var\.ns|:var\.name|:from-var|:to-var`, plus broad file-structure and content exploration
 - **Key files examined**:

--- a/docs/research/issue-30-dialect-compat-planning.md
+++ b/docs/research/issue-30-dialect-compat-planning.md
@@ -1,11 +1,22 @@
+---
+type: Research
+title: "Planning: Cross-Dialect Compatibility Indicators"
+description: Planning for Clojure/CLJS/babashka compatibility indicators (issue #30).
+tags: [research, issue-30, dialect-compat, planning]
+created: 2026-04-14
+modified: 2026-04-28
+source: https://github.com/nubank/clojuredocs/issues/30
+creator: L. Jordan Miller
+contributors: [David Nolen (ClojureScript), Michiel Borkent (babashka)]
+review_maturity: L2
+review_note: Human-directed planning; named reviewers listed as contributors.
+---
+
 # Planning: Cross-Dialect Compatibility Indicators
 
-> **Issue:** [nubank/clojuredocs#30](https://github.com/nubank/clojuredocs/issues/30)
-> **Branch:** `research/30/dialect-compat-planning`
-> **Author:** L. Jordan Miller
-> **Reviewers:** David Nolen (ClojureScript), Michiel Borkent (babashka)
-> **Date started:** 2026-04-14 ([`02c9802`](https://github.com/nubank/clojuredocs/commit/02c980200923afdc502176eba6aea62ce2fe92f3))
-> **Last updated:** 2026-04-28
+> **Issue:** [nubank/clojuredocs#30](https://github.com/nubank/clojuredocs/issues/30) ·
+> **Branch:** `research/30/dialect-compat-planning` ·
+> started [`02c9802`](https://github.com/nubank/clojuredocs/commit/02c980200923afdc502176eba6aea62ce2fe92f3)
 
 ---
 

--- a/docs/rfcs/okf-metadata-rfc.md
+++ b/docs/rfcs/okf-metadata-rfc.md
@@ -1,0 +1,198 @@
+---
+type: RFC
+title: OKF + RDF-aligned document metadata convention
+description: Replace the blockquote metadata block with OKF YAML frontmatter whose semantics align to Dublin Core Terms and PROV-O.
+tags: [rfc, ai-metadata, okf, rdf, dublin-core, prov-o, conventions]
+created: 2026-06-16
+modified: 2026-06-16
+source: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a/okf/SPEC.md
+ai_assisted: "Claude Opus 4.8 via Claude Code"
+tools: [GitHub MCP, WebFetch, workspace files]
+agents_skills: []
+review_maturity: L2
+review_note: human-directed; OKF/RDF claims sourced to primary specs; pending PR review
+---
+
+# RFC: OKF + RDF-aligned document metadata convention
+
+> **Caveat:** AI-drafted from human direction. The framework claims — the [Open Knowledge Format (OKF)](#sources), [Dublin Core Terms](#sources), and the W3C Provenance Ontology ([PROV-O](#sources)) — are sourced to the primary specifications listed in [Sources](#sources), each fetched June 2026 (the OKF spec link is pinned to a commit). Verify against those before treating any mapping as authoritative.
+
+## Context
+
+Prose documents under `docs/` carry AI provenance and review metadata. The current convention
+([CLAUDE.md](../../CLAUDE.md) → "AI metadata on documents") encodes that metadata as a Markdown
+**blockquote** (`> **Document metadata**` + bold-label bullets). This RFC proposes replacing the blockquote
+with **YAML frontmatter** that is conformant with the [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a/okf/SPEC.md)
+and whose field *semantics* align with two established RDF vocabularies —
+[Dublin Core Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/) and
+[W3C PROV-O](https://www.w3.org/TR/prov-o/).
+
+This is the **Library** rung of the reliability ratchet (LLM → REPL → Library → Enforcement): the convention
+becomes a parseable, shared format. A `bb` validator (the **Enforcement** rung) is a deliberate follow-up.
+
+## Problem
+
+The blockquote is human-readable but **not machine-parseable**. Comparing it to OKF v0.1 surfaces concrete
+deviations:
+
+1. **Frontmatter format — hard conflict.** OKF *mandates* a YAML frontmatter block delimited by `---`
+   (OKF §4.1). A blockquote yields **no frontmatter**, so a conformant OKF consumer treats the document as
+   having none — failing conformance (OKF §9.1).
+2. **Required `type` — absent.** OKF requires a non-empty `type` field (OKF §9.2) — effectively its one
+   mandatory field; Claude found no other hard requirement in the spec. The blockquote has no `type`.
+3. **Field-name divergence.** Only `tags` overlaps OKF, and as prose (`Tags: a, b`) rather than a YAML list.
+4. **Review-trust is not queryable.** The L0–L4 maturity level, section `<!-- reviewed -->` markers, and
+   `[unverified]` flags live in prose and HTML comments — invisible to any structured consumer.
+
+What the current conventions already get **right** (and this RFC keeps): metadata stored as code in version
+control (OKF §10, "metadata as code"); structural Markdown over freeform prose (OKF §4.2); cross-links as a
+graph (OKF §5); a permissive, progressive-trust posture (OKF §9) — our L0–L4 ladder is our own, stricter
+extension of that idea, not part of OKF; and dated change history (OKF's `log.md` and our per-doc Version
+History tables both serve this end).
+
+## Proposal
+
+### Frontmatter
+
+```yaml
+---
+type: RFC                              # REQUIRED (OKF) — dcterms:type
+title: OKF + RDF-aligned document metadata convention   # dcterms:title
+description: One-line summary used by indexes, search, and previews.   # dcterms:description
+tags: [rfc, ai-metadata, okf, rdf]     # dcterms:subject
+created: 2026-06-16                    # dcterms:created
+modified: 2026-06-16                   # dcterms:modified
+source: https://github.com/nubank/clojuredocs/issues/43   # dcterms:source (when one exists)
+ai_assisted: "Claude Opus 4.8 via Claude Code"            # prov:wasAttributedTo a prov:SoftwareAgent
+session: <session-id>                  # identifies the prov:Activity
+tools: [GitHub MCP, workspace files]   # prov:used
+agents_skills: []                      # permalinks to agent/skill definitions applied
+review_maturity: L2                    # machine-readable L0–L4
+review_note: human-reviewed via PR
+---
+```
+
+**Required:** `type`. **Recommended:** `title`, `description`, `tags`, `created`, `modified`.
+**Provenance (when AI-assisted):** `ai_assisted`, `session`, `tools`, `agents_skills`.
+**Review trust:** `review_maturity`, `review_note`. Consumers tolerate unknown keys and unknown `type`
+values (OKF §9).
+
+### `type` taxonomy
+
+`Reference`, `Guide`, `RFC`, `Decision Log`, `Errata`, `Data Model`, `Diagram`, `Research`, `Review`,
+`Vision`. Descriptive and extensible. This is *our* controlled vocabulary, supplied as the value of the
+`dcterms:type` slot — it is not DCMI's recommended Type Vocabulary (`Text`, `Dataset`, `Software`, …).
+
+### RDF alignment — additive, never required
+
+The **required surface stays pure OKF** (`type` + YAML). Field names map to well-known RDF terms so the same
+frontmatter is liftable to triples; nothing forces a consumer to care.
+
+| Frontmatter key | RDF term | Meaning |
+|---|---|---|
+| `type` | `dcterms:type` | Nature/genre of the document (also OKF's required field) |
+| `title` | `dcterms:title` | Name |
+| `description` | `dcterms:description` | One-line account |
+| `tags` | `dcterms:subject` | Topics |
+| `created` | `dcterms:created` | Date of creation |
+| `modified` | `dcterms:modified` | Date of last meaningful change |
+| `source` | `dcterms:source` | Related resource the document is based on. (Use `prov:wasDerivedFrom` only when there is a true derivation, not a mere reference.) |
+| `ai_assisted` | `prov:wasAttributedTo` a `prov:SoftwareAgent` | Model/interface that generated the draft |
+| `tools` | `prov:used` | What the generating activity used |
+| `review_maturity` / `review_note` | extension (no native OKF/RDF equivalent) | Human review trust; at L4 the human owner can be recorded as `dcterms:creator` / a `prov:Person` the entity is `prov:wasAttributedTo` |
+
+PROV-O provides terms that fit this case: the document is a `prov:Entity` that `prov:wasGeneratedBy` an
+activity and `prov:wasAttributedTo` a `prov:SoftwareAgent` (the model) which `prov:actedOnBehalfOf` a
+`prov:Person` (the human owner). The canonical mapping ships as an out-of-band JSON-LD context,
+[`docs/context.jsonld`](../context.jsonld), so the document files stay plain YAML you can `cat`.
+
+### What stays in the body
+
+Section-level `<!-- reviewed: name, date — scope -->` markers, inline `[unverified]` flags, and scope/caveat
+disclaimers remain in the body — OKF tolerates them; they are not structured fields.
+
+### OKF bundle root
+
+`docs/` becomes an OKF bundle: [`docs/index.md`](../index.md) carries `okf_version: "0.1"` (the only
+frontmatter an index may have, OKF §11) and lists documents for progressive disclosure (OKF §6).
+
+## Why RDF (Dublin Core + PROV-O)
+
+- **Dublin Core Terms** is a long-established W3C-adjacent vocabulary for descriptive and lifecycle metadata;
+  `dcterms:type` covers the same ground as OKF's required field, so alignment is nearly free.
+- **PROV-O** is a W3C Recommendation providing an OWL ontology for provenance; its terms directly support
+  "an entity generated by a software agent on behalf of a person" — precisely AI-assisted authorship.
+- Keeping it **additive** (vocabulary + optional `@context`, not mandated IRIs/Turtle) respects OKF's
+  deliberate minimalism — per the spec, *"If you can `cat` a file, you can read OKF; if you can `git clone`
+  a repo, you can ship it."*
+
+## Principles carried over
+
+Generic, publicly-sourced principles reinforced by this convention: provenance is mandatory for AI-assisted
+docs; citations should be reproducible (commit-pinned GitHub permalinks for code); git is the system of
+record; structure beats prose; humans take ownership at L4. These echo OKF, DCMI, PROV-O,
+[C2PA](https://c2pa.org/) content credentials, the Linux kernel `Reviewed-by` trailer, and Datomic's
+immutable/transactional model.
+
+## Alternatives considered
+
+1. **Parse the blockquote with `bb` (regex/grammar).** Cheapest, zero doc changes — but brittle, non-standard,
+   and not OKF-conformant. Rejected.
+2. **Prefixed `dcterms:`/`prov:` keys directly in YAML.** Unambiguous RDF, but noisy and un-OKF-idiomatic.
+   Bare keys + `docs/context.jsonld` yield the same triples with cleaner files. Rejected.
+3. **Full RDF serialization (Turtle / JSON-LD documents).** Runs against OKF's minimalism and is heavyweight
+   for a `docs/` tree. Rejected.
+4. **Keep the blockquote.** That is the problem. Rejected.
+
+## Migration
+
+Full sweep of prose Markdown under `docs/` to frontmatter. On `master` that is the 13 current prose `.md`
+files under `docs/` (excluding `.github/` templates and data files; count as of branch base `feb227c`); the
+documents living on `feat/43` (entity model, errata, dataflows, the entity-model RFC) get frontmatter when
+that branch lands. Out of scope: `.github/` templates (GitHub-mandated frontmatter), repo-root config, and
+data files (`*.edn`, `*.csv` — not OKF concepts).
+
+## Enforcement (follow-up PR)
+
+A `bb` validator + `schema.edn` checking: every non-reserved `docs/**.md` has parseable frontmatter; `type`
+is non-empty and in the taxonomy; `review_maturity ∈ {L0..L4}`; dates are ISO 8601. Wired into
+`clojure.test`. This is the ratchet's final rung — `vibes+prose → sidecar.clj → schema.edn → clojure.test`.
+
+## Open questions
+
+- Should `review_maturity` gain an explicit human-owner field (`reviewed_by`) to fully realize the PROV-O
+  `prov:Person` attribution at L4? Deferred to the enforcement PR.
+- Whether to generate `docs/index.md` from frontmatter automatically (OKF §6 permits it). Deferred.
+
+> Review log: [okf-metadata-rfc_research-review_run_1.md](okf-metadata-rfc_research-review_run_1.md) — claims/link audit, fixes applied and items deferred.
+
+## Version history
+
+| Date | Change |
+|---|---|
+| 2026-06-16 | Initial RFC: propose OKF YAML frontmatter with Dublin Core + PROV-O semantics; supersede the blockquote block. |
+
+## Sources
+
+**Specifications & code (primary)**
+
+| Source | Relevance | Quality |
+|---|---|---|
+| [OKF v0.1 spec](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a/okf/SPEC.md) | Critical — the format this RFC conforms to | Excellent (primary spec); commit-pinned |
+| [knowledge-catalog repo](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/2d0bb3f547b847fcbd1c7611bdab8a9e2ccb098f) | High — reference implementation and samples | Good; commit-pinned |
+
+**Public references**
+
+| Source | Relevance | Quality |
+|---|---|---|
+| [DCMI Metadata Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/) | Critical — `dcterms:` field semantics | Excellent (W3C-adjacent standard) |
+| [W3C PROV-O](https://www.w3.org/TR/prov-o/) | Critical — provenance model for AI authorship | Excellent (W3C Recommendation) |
+| [OKF announcement blog](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/) | Medium — motivation and framing | Good (vendor blog; defer to SPEC) |
+| [C2PA](https://c2pa.org/) | Medium — progressive-trust analogy for L0–L4 | Good |
+| [Linux kernel submitting-patches (`Reviewed-by`)](https://docs.kernel.org/process/submitting-patches.html) | Medium — review-trailer convention | Excellent (primary) |
+
+**Not accessed / out of scope**
+
+| Source | Reason |
+|---|---|
+| Internal Nubank context-engineering conventions | Intentionally excluded — this is a public repository; internal conventions are tracked separately. |

--- a/docs/rfcs/okf-metadata-rfc_research-review_run_1.md
+++ b/docs/rfcs/okf-metadata-rfc_research-review_run_1.md
@@ -1,0 +1,68 @@
+---
+type: Review
+title: "Research-review run 1 — OKF + RDF metadata RFC"
+description: Prioritized claims/link audit of okf-metadata-rfc.md; fixes applied and items deferred.
+tags: [review, research-review, okf, rdf]
+created: 2026-06-16
+modified: 2026-06-16
+source: okf-metadata-rfc.md
+ai_assisted: "Claude Opus 4.8 via Claude Code"
+agents_skills: [claims-auditor, link-auditor]
+review_maturity: L1
+review_note: AI-generated review log — verify before actioning deferred items.
+---
+
+# Research-review run 1 — OKF + RDF metadata RFC
+
+Review of [okf-metadata-rfc.md](okf-metadata-rfc.md) via the `/research-review` skill (claims-auditor +
+link-auditor), 2026-06-16. Action codes: **FIXED** (applied to the RFC this run) · **DEFERRED** (left for a
+human) · **N/A**.
+
+## Priority 1 — Factual concerns (claims-auditor)
+
+- **Auditor "root concern" that OKF may be hallucinated — RESOLVED, not a defect.** The claims-auditor's
+  training cutoff predates OKF; it could not confirm the spec exists. OKF v0.1 was fetched from the live
+  `GoogleCloudPlatform/knowledge-catalog` repo in June 2026 and the spec link is now commit-pinned. No action
+  on the RFC beyond the pin.
+- **FIXED** — Overstated absolutes softened: "single hard requirement" → "effectively its one mandatory
+  field; Claude found no other"; "the W3C standard for provenance" → "a W3C Recommendation"; "the canonical
+  way" / "widely-deployed" reworded.
+- **FIXED** — `dcterms:type` misattribution: clarified the taxonomy is *our* controlled vocabulary supplied
+  as the `dcterms:type` value, **not** DCMI's recommended Type Vocabulary.
+- **FIXED** — "PROV-O models our exact case" → "provides terms that fit this case".
+- **FIXED** — `source` row split from `prov:wasDerivedFrom` (different semantics); the "cat a file" line is now
+  attributed as a direct spec quote.
+- **DEFERRED** — Convert every inline `OKF §N` reference (§4.1, §4.2, §5, §6, §9, §9.1, §9.2, §10, §11) into an
+  anchored permalink into the pinned `SPEC.md`, so each section claim is one click to verify. Numerous;
+  mechanical but not done this run.
+
+## Priority 2 — Navigation concerns (link-auditor)
+
+- **FIXED** — OKF spec link and `knowledge-catalog` repo link commit-pinned (were `/blob/main`, `/tree/main`).
+- **FIXED** — First-mention acronyms expanded/linked in the Caveat (OKF, Dublin Core Terms, PROV-O = W3C
+  Provenance Ontology).
+- **DEFERRED** — Optionally link each RDF term cell in the alignment table (`dcterms:*`, `prov:*`) to its
+  canonical fragment. Judgment call: full linking adds noise; a representative link per vocabulary may suffice.
+- **DEFERRED** — Minor display-text trims (`SPEC.md` → "spec"; `docs/context.jsonld` label). Low priority; the
+  file paths are arguably load-bearing in an RFC about file conventions.
+- **OK** — All relative links (`../../CLAUDE.md`, `../context.jsonld`, `../index.md`) resolve on this branch.
+  `entity-model-rfc.md` is referenced only in prose (not a link), so it is not broken.
+
+## Priority 3 — Source concerns
+
+- **OK** — Annotated bibliography present, grouped (specs/code, public references, not-accessed), with
+  relevance + quality assessments.
+
+## Priority 4 — Process concerns
+
+- **OK** — Version History present with a 2026-06-16 entry.
+- **N/A** — No Errata section: this is an RFC, not a running research document; errata would attach to the
+  superseded blockquote convention if errors surface later.
+
+## Cross-cutting — Confidentiality (needs human decision)
+
+- **RESOLVED** — A pre-existing line in
+  [docs/research/data-model-coupling-audit.md](../research/data-model-coupling-audit.md) (Research Context)
+  named a private internal repository as the origin of a "research-analyst" agent. This PR did not introduce
+  it, but it was in the changed-file set; naming a private repo in a public doc is a confidentiality smell. It
+  was rephrased to "adapted from an internal agent definition".


### PR DESCRIPTION
## Context

Document AI-provenance/review metadata is currently a Markdown blockquote (`> **Document metadata**`), defined in [CLAUDE.md](../blob/feat/okf-metadata-conventions/CLAUDE.md). It is human-readable but not machine-parseable. This is no longer scoped to #43 — the goal is AI-config changes.

## Problem

The blockquote is non-conformant with the [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a/okf/SPEC.md): no frontmatter, no required `type`. A conformant consumer sees no metadata. The L0–L4 review-trust signals and `[unverified]` markers live in prose, so nothing can validate them.

## Solution

Replace the blockquote with YAML frontmatter conformant to OKF (required `type`), with field semantics aligned to [Dublin Core Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/) and [PROV-O](https://www.w3.org/TR/prov-o/). RDF stays **additive** via an optional JSON-LD `@context`; the required surface remains pure OKF. The L0–L4 maturity model is kept as a queryable `review_maturity` field.

- `CLAUDE.md` + `.github/copilot-instructions.md` — rewrite the metadata convention.
- `docs/rfcs/okf-metadata-rfc.md` — the proposal as an RFC (with a research-review log).
- `docs/context.jsonld` — JSON-LD `@context` mapping keys → `dcterms:`/`prov:` IRIs.
- `docs/index.md` — OKF bundle root (`okf_version: "0.1"`).
- Migrate all 13 prose docs under `docs/` to frontmatter; record the decision in `docs/decisions.md`.

Verified: 15/15 non-reserved `docs/**.md` carry frontmatter + non-empty `type`; `context.jsonld` is valid JSON. A `bb` validator is a planned follow-up (the Enforcement rung).

<details>
<summary>Father Watson Questions</summary>

- **What do we know?** OKF mandates YAML frontmatter + `type`; Dublin Core and PROV-O give well-known semantics for our descriptive and provenance fields. The blockquote fails OKF conformance.
- **What do we need to know?** Whether the type taxonomy and the dcterms/PROV-O mapping hold up under review; whether `review_maturity` should gain an explicit `reviewed_by` (`prov:Person`) field.
- **Where are we?** Convention rewritten; all 13 master docs migrated; `docs/` is now an OKF bundle. Branched off `master` (this remote has no `main`). The 5 `feat/43` docs migrate when that branch lands.
- **Where are we going?** A `bb` validator + `schema.edn` + `clojure.test` enforcing the format — the final ratchet rung.

</details>

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>