### PR TITLE
feat: enforce OKF doc-metadata convention with a bb validator

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Pre-commit: validate OKF + RDF document metadata before the commit lands.
+# Enable once per clone:  bin/install-hooks   (or: git config core.hooksPath .githooks)
+# Bypass in a pinch:       git commit --no-verify
+#
+# Runs the same validator as CI and `lein test` (single source of truth).
+
+if ! command -v bb >/dev/null 2>&1; then
+  echo "pre-commit: babashka (bb) not found on PATH — skipping doc-metadata check." >&2
+  echo "            install bb or run with --no-verify to bypass." >&2
+  exit 0
+fi
+
+exec bb tools/validate_metadata.clj

--- a/.github/workflows/docs-metadata.yml
+++ b/.github/workflows/docs-metadata.yml
@@ -1,0 +1,33 @@
+name: docs-metadata
+
+# Authoritative remote gate for the OKF + RDF document-metadata convention.
+# Runs the same validator as the local pre-commit hook and `lein test`.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'tools/validate_metadata.clj'
+      - 'docs/metadata-schema.edn'
+      - 'docs/context.jsonld'
+      - 'CLAUDE.md'
+      - '.github/workflows/docs-metadata.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - 'tools/validate_metadata.clj'
+      - 'docs/metadata-schema.edn'
+      - 'docs/context.jsonld'
+
+jobs:
+  validate-docs-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install babashka
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          bb: latest
+      - name: Validate doc metadata
+        run: bb tools/validate_metadata.clj

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A few ways to contribute:
 * Suggestions on how to make development on the site more friendly
   (docs, codebase organization).
 
+Docs under `docs/` follow a metadata convention (see [CLAUDE.md](CLAUDE.md));
+run `bin/install-hooks` once to enable the pre-commit check, or validate with
+`bb tools/validate_metadata.clj`.
+
 Let's use GH issues for discussion for now
 
 If you're looking for a project:
@@ -51,6 +55,7 @@ the full release checklist, SSH setup, and smoke tests.
 * [lein](http://leiningen.org)
 * [foreman](https://github.com/ddollar/foreman) (see `Procfile`, `bin/dev`)
 * [entr](http://entrproject.org/) (available in homebrew)
+* [babashka](https://babashka.org) (`bb`) (repo tooling + doc-metadata hook)
 * MongoDB
 
 

--- a/bin/install-hooks
+++ b/bin/install-hooks
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Enable this repo's git hooks (pre-commit doc-metadata validation).
+# Run once after cloning:  bin/install-hooks
+set -e
+git config core.hooksPath .githooks
+echo "Git hooks enabled (core.hooksPath = .githooks)."
+echo "pre-commit will run: bb tools/validate_metadata.clj"

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ title: Documentation
 description: Documentation map for the nubank/clojuredocs repo.
 tags: [docs, index, navigation]
 created: 2026-06-09
-modified: 2026-06-09
+modified: 2026-06-16
 ai_assisted: "Claude Opus 4.6 via GitHub Copilot"
 review_maturity: L2
 review_note: Human-reviewed via PR.
@@ -22,6 +22,7 @@ Doc map for [nubank/clojuredocs](https://github.com/nubank/clojuredocs).
 | [Glossary](glossary.md) | Domain terms and definitions |
 | [Decisions](decisions.md) | Decision log — design and architecture choices |
 | [Library Layers](lib-layers.md) | Dependency layers of the codebase |
+| [OKF Metadata RFC](rfcs/okf-metadata-rfc.md) | Document-metadata convention (OKF + RDF frontmatter) and its enforcement |
 
 ## Development
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -17,6 +17,28 @@ Document design and architecture decisions. Lightweight alternative to full ADRs
 
 ---
 
+## 2026-06-16 — Enforce doc metadata with a bb validator (three surfaces)
+
+### Status
+Decided
+
+### Context
+The OKF + RDF frontmatter convention was adopted but unenforced — nothing prevented drift or caught a missing
+`type` / bad `review_maturity`.
+
+### Decision
+Add [tools/validate_metadata.clj](../tools/validate_metadata.clj) (babashka) validating `docs/**.md` against
+[docs/metadata-schema.edn](metadata-schema.edn), wired into three surfaces: a git pre-commit hook
+(`.githooks/pre-commit`, enabled via `bin/install-hooks`), `lein test` (`clojuredocs.metadata-test`), and CI
+(`.github/workflows/docs-metadata.yml`). The `bb` script is the single source of truth; the test and hook
+shell out to it. `metadata-schema.edn` is the editable source of truth for the taxonomy and field rules.
+
+### Consequences
+Bad frontmatter fails fast locally (hook), in the suite (`lein test`), and authoritatively on PRs (CI). New
+`type` values or fields are changed in one place (`metadata-schema.edn`).
+
+---
+
 ## 2026-06-16 — Adopt OKF + RDF-aligned YAML frontmatter for doc metadata
 
 ### Status

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -4,7 +4,7 @@ title: Dev Environment Setup
 description: Notes for getting a local development environment running.
 tags: [dev-setup, mongodb, leiningen]
 created: 2026-02-27
-modified: 2026-02-27
+modified: 2026-06-16
 review_maturity: L2
 review_note: Human-authored setup notes; frontmatter added during OKF migration.
 ---
@@ -18,6 +18,23 @@ Supplementary notes for getting a local development environment running. See als
 - Java (JDK 8+)
 - [Leiningen](https://leiningen.org)
 - MongoDB running locally
+- [babashka](https://babashka.org) (`bb`) — for repo tooling and the doc-metadata pre-commit hook
+
+## Git hooks
+
+Enable the repo's pre-commit hook so document metadata is validated before each commit:
+
+```bash
+bin/install-hooks
+```
+
+This points `core.hooksPath` at `.githooks`; the hook runs `bb tools/validate_metadata.clj` — the same check CI runs. Validate manually any time with:
+
+```bash
+bb tools/validate_metadata.clj
+```
+
+See [CLAUDE.md](../CLAUDE.md) for the metadata convention and the [OKF metadata RFC](rfcs/okf-metadata-rfc.md) for rationale.
 
 ## MongoDB
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,7 +4,7 @@ title: Glossary
 description: Domain terms as used in this codebase and design docs.
 tags: [glossary, domain-terms]
 created: 2026-03-04
-modified: 2026-03-04
+modified: 2026-06-16
 ai_assisted: "Claude Opus 4.6 (1M context) via Claude Code"
 review_maturity: L1
 review_note: AI-drafted research; see in-body disclaimer — claims not individually verified.
@@ -93,6 +93,10 @@ Terms as used in [issue #4](https://github.com/nubank/clojuredocs/issues/4) anal
 *Source*: [`search/static.clj` lines 3–39](https://github.com/nubank/clojuredocs/blob/master/src/clj/clojuredocs/search/static.clj#L3-L39) (the flat list); [Clojure reference on namespaces](https://clojure.org/reference/namespaces).
 
 ## R
+
+**reliability ratchet** — Turning something an AI or engineer discovered informally into a progressively more deterministic, reusable artifact, so future runs are faster, more repeatable, and easier to trust: **LLM → REPL → Library → Enforcement**. Each step hardens the one before it — a finding checked in a REPL becomes a library/schema, which becomes an enforced test. In this repo, the [document-metadata convention](rfcs/okf-metadata-rfc.md) (Library) is enforced by [`tools/validate_metadata.clj`](../tools/validate_metadata.clj) against [`metadata-schema.edn`](metadata-schema.edn) (Enforcement).
+
+*Source*: [CLAUDE.md](../CLAUDE.md), "Reliability ratchet".
 
 **routes** — [Compojure](#c) route definitions that map URL patterns to handler functions. Three route tables exist: page routes in [`pages.clj`](https://github.com/nubank/clojuredocs/blob/master/src/clj/clojuredocs/pages.clj#L311-L358) (namespace pages, var pages, search, core-library, quickref), API routes in [`api/server.clj`](https://github.com/nubank/clojuredocs/blob/master/src/clj/clojuredocs/api/server.clj#L34-L51) (CRUD for examples, notes, see-alsos), and legacy redirect routes in [`entry.clj`](https://github.com/nubank/clojuredocs/blob/master/src/clj/clojuredocs/entry.clj#L86-L100) (old ClojureDocs URL patterns redirected to current URLs). Composed into a single handler in `entry.clj`.
 

--- a/docs/metadata-schema.edn
+++ b/docs/metadata-schema.edn
@@ -1,0 +1,38 @@
+;; Source of truth for the OKF + RDF document-metadata convention.
+;; Consumed by tools/validate_metadata.clj. See docs/rfcs/okf-metadata-rfc.md
+;; for rationale and CLAUDE.md ("AI metadata on documents") for the human spec.
+;;
+;; This is a data file, not a prose document, so it carries no frontmatter.
+{;; OKF's one hard requirement.
+ :required        #{:type}
+
+ ;; Controlled vocabulary for `type` (= dcterms:type). Extensible: add values
+ ;; here rather than repurposing existing ones. Unknown types warn, not fail.
+ :types           #{"Reference" "Guide" "RFC" "Decision Log" "Errata"
+                    "Data Model" "Diagram" "Research" "Review" "Vision"}
+
+ ;; Review-trust ladder (our extension over OKF/RDF).
+ :review-maturity #{"L0" "L1" "L2" "L3" "L4"}
+
+ ;; Keys whose value must be an ISO 8601 date (date or datetime).
+ :date-keys       #{:created :modified}
+
+ :recommended     #{:title :description :tags :created :modified}
+
+ ;; Every key the convention defines. Unknown keys warn (possible typo), since
+ ;; OKF tolerates producer extensions.
+ :known-keys      #{:type :title :description :tags :created :modified :source
+                    :creator :contributors :ai_assisted :session :tools
+                    :agents_skills :review_maturity :review_note :okf_version}
+
+ ;; OKF-reserved filenames (skipped from concept validation).
+ :reserved-files  #{"index.md" "log.md"}
+
+ ;; The OKF bundle root: the one index.md permitted frontmatter (okf_version only).
+ :bundle-root     "docs/index.md"
+ :okf-version     "0.1"
+
+ ;; JSON-LD context that maps frontmatter keys to dcterms:/prov: IRIs. Every
+ ;; known key except those listed in :context-exempt must have a mapping there.
+ :context-file    "docs/context.jsonld"
+ :context-exempt  #{:okf_version}}

--- a/docs/rfcs/okf-metadata-rfc.md
+++ b/docs/rfcs/okf-metadata-rfc.md
@@ -152,11 +152,19 @@ documents living on `feat/43` (entity model, errata, dataflows, the entity-model
 that branch lands. Out of scope: `.github/` templates (GitHub-mandated frontmatter), repo-root config, and
 data files (`*.edn`, `*.csv` — not OKF concepts).
 
-## Enforcement (follow-up PR)
+## Enforcement
 
-A `bb` validator + `schema.edn` checking: every non-reserved `docs/**.md` has parseable frontmatter; `type`
-is non-empty and in the taxonomy; `review_maturity ∈ {L0..L4}`; dates are ISO 8601. Wired into
-`clojure.test`. This is the ratchet's final rung — `vibes+prose → sidecar.clj → schema.edn → clojure.test`.
+Implemented: [`tools/validate_metadata.clj`](../../tools/validate_metadata.clj) (babashka) validates every
+non-reserved `.md` under `docs/` (recursively) against [`docs/metadata-schema.edn`](../metadata-schema.edn) —
+parseable frontmatter; non-empty `type` (warns if outside the taxonomy); `review_maturity ∈ {L0..L4}`;
+`created`/`modified` are valid `YYYY-MM-DD` dates (validated against the raw text, since clj-yaml leniently
+rolls bad dates over); and that every known frontmatter key except `okf_version` has a JSON-LD mapping in
+[`docs/context.jsonld`](../context.jsonld). One validator, three surfaces: a git pre-commit hook
+([`.githooks/pre-commit`](../../.githooks/pre-commit), enabled via [`bin/install-hooks`](../../bin/install-hooks)),
+`lein test` ([`clojuredocs.metadata-test`](../../test/clojuredocs/metadata_test.clj)), and CI
+([`.github/workflows/docs-metadata.yml`](../../.github/workflows/docs-metadata.yml)). This completes the
+**Enforcement** rung of the reliability ratchet (LLM → REPL → Library → Enforcement) — concretely,
+`vibes+prose → sidecar.clj → schema.edn → clojure.test`.
 
 ## Open questions
 
@@ -164,13 +172,14 @@ is non-empty and in the taxonomy; `review_maturity ∈ {L0..L4}`; dates are ISO 
   `prov:Person` attribution at L4? Deferred to the enforcement PR.
 - Whether to generate `docs/index.md` from frontmatter automatically (OKF §6 permits it). Deferred.
 
-> Review log: [okf-metadata-rfc_research-review_run_1.md](okf-metadata-rfc_research-review_run_1.md) — claims/link audit, fixes applied and items deferred.
+> Review logs: [run 1](okf-metadata-rfc_research-review_run_1.md) (initial claims/link audit) · [run 2](okf-metadata-rfc_research-review_run_2.md) (post-enforcement audit) — fixes applied, items deferred.
 
 ## Version history
 
 | Date | Change |
 |---|---|
 | 2026-06-16 | Initial RFC: propose OKF YAML frontmatter with Dublin Core + PROV-O semantics; supersede the blockquote block. |
+| 2026-06-16 | Enforcement implemented: `bb` validator + `metadata-schema.edn`, wired into a pre-commit hook, `lein test`, and CI. |
 
 ## Sources
 

--- a/docs/rfcs/okf-metadata-rfc_research-review_run_2.md
+++ b/docs/rfcs/okf-metadata-rfc_research-review_run_2.md
@@ -1,0 +1,57 @@
+---
+type: Review
+title: "Research-review run 2 — OKF metadata RFC (enforcement)"
+description: Second claims/link audit after enforcement was implemented; fixes applied.
+tags: [review, research-review, okf, enforcement]
+created: 2026-06-16
+modified: 2026-06-16
+source: okf-metadata-rfc.md
+ai_assisted: "Claude Opus 4.8 via Claude Code"
+agents_skills: [claims-auditor, link-auditor]
+review_maturity: L1
+review_note: AI-generated review log — verify before actioning deferred items.
+---
+
+# Research-review run 2 — OKF metadata RFC (enforcement)
+
+Second `/research-review` of [okf-metadata-rfc.md](okf-metadata-rfc.md), run after the `## Enforcement`
+section changed from "follow-up" to "implemented". Action codes: **FIXED** · **DEFERRED** · **OK**.
+
+Both auditors **verified the enforcement claim is true**: `tools/validate_metadata.clj`,
+`docs/metadata-schema.edn`, `.githooks/pre-commit`, `bin/install-hooks`, `test/clojuredocs/metadata_test.clj`,
+and `.github/workflows/docs-metadata.yml` all exist on the branch and wire together as described. Remaining
+items were precision/links.
+
+## Priority 1 — Factual concerns (claims-auditor)
+
+- **FIXED (substantive)** — "ISO 8601 dates" overstated a shape-only regex. The validator now parses the raw
+  authored `created`/`modified` text with `java.time.LocalDate`, rejecting impossible (`2026-13-45`),
+  unpadded (`2026-6-6`), and non-date values. Validating the *parsed* value could not catch this — clj-yaml
+  leniently rolls `2026-13-45` over to a real `Date`. The RFC now says "valid `YYYY-MM-DD` dates (validated
+  against the raw text)".
+- **FIXED** — "every schema key has a mapping in context.jsonld" → "every known frontmatter key except
+  `okf_version`" (the validator checks `:known-keys` minus `:context-exempt`, not schema config keys).
+- **FIXED (tone)** — Dropped "the ratchet's final rung"; aligned to the canonical ratchet
+  (LLM → REPL → Library → Enforcement) and kept the concrete `vibes+prose → … → clojure.test` framing as an
+  illustration, not a competing ladder.
+- **FIXED (cosmetic)** — `docs/**.md` → "every `.md` under `docs/` (recursively)".
+- **OK** — Migration count "13 … as of `feb227c`" is commit-scoped (acceptable). The L4/`type`/absence claims
+  from run 1 remain correctly scoped.
+
+## Priority 2 — Navigation concerns (link-auditor)
+
+- **FIXED** — The four implemented artifacts cited as bare code are now relative links
+  (`.githooks/pre-commit`, `bin/install-hooks`, `clojuredocs.metadata-test`, the CI workflow), matching how
+  the sibling artifacts are linked. All five pre-existing relative links resolve.
+- **DEFERRED (soft)** — Some link display text repeats the file path (e.g. `tools/validate_metadata.clj`).
+  Judgment call: in an RFC about file conventions the exact paths are load-bearing, so left as-is.
+- **OK** — `lein test` unlinked (well-known tool); PROV-O term cluster covered by the section's PROV-O link.
+
+## Priority 3 / 4 — Sources & process
+
+- **OK** — Bibliography present and grouped; Version History has the 2026-06-16 enforcement row. No Errata
+  section (RFC, not a running research doc).
+
+## Cross-cutting
+
+- **OK** — Confidentiality: no internal-only mechanics or private-repo names (resolved in run 1).

--- a/test/clojuredocs/metadata_test.clj
+++ b/test/clojuredocs/metadata_test.clj
@@ -1,0 +1,22 @@
+(ns clojuredocs.metadata-test
+  "Enforces the OKF + RDF document-metadata convention under `lein test`.
+
+  This is a thin wrapper: it shells out to the single source of truth,
+  `tools/validate_metadata.clj` (run by babashka), and asserts a clean exit.
+  Keeping one validator means the hook, CI, and this test enforce the same rules.
+  Requires `bb` on PATH."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.shell :as sh]))
+
+(deftest docs-metadata-frontmatter
+  (testing "every docs/**.md frontmatter conforms to docs/metadata-schema.edn"
+    (let [result (try (sh/sh "bb" "tools/validate_metadata.clj")
+                      (catch java.io.IOException _ ::no-bb))]
+      (if (= result ::no-bb)
+        (is false "babashka (bb) must be on PATH to run the doc-metadata validator")
+        (let [{:keys [exit out err]} result]
+          (when-not (zero? exit)
+            (println out)
+            (when (seq err) (println err)))
+          (is (zero? exit)
+              "doc-metadata validation failed — see tools/validate_metadata.clj output above"))))))

--- a/tools/README.md
+++ b/tools/README.md
@@ -34,6 +34,26 @@ Regenerate when any of these change:
 
 The generated file includes a `:versions` header for traceability.
 
+## `validate_metadata.clj`
+
+Validates the OKF + RDF YAML frontmatter on every prose doc under `docs/` against
+[`docs/metadata-schema.edn`](../docs/metadata-schema.edn) (the source of truth). Enforces the convention in
+[CLAUDE.md](../CLAUDE.md) and [docs/rfcs/okf-metadata-rfc.md](../docs/rfcs/okf-metadata-rfc.md).
+
+### How to run
+
+```sh
+bb tools/validate_metadata.clj   # from the repo root
+```
+
+Prints `PASS`/`FAIL` per document and a summary. **Exits non-zero if any document has an error**, so it can
+gate a commit or a CI job. Errors fail the run (missing frontmatter, missing required `type`, invalid
+`review_maturity`, malformed date); unknown `type` values and unknown keys are warnings. Also checks that
+every schema key has a JSON-LD mapping in [`docs/context.jsonld`](../docs/context.jsonld).
+
+Requires **babashka** (`bb`) on `$PATH` — it uses bb's bundled `clj-yaml` and `cheshire`, so no JVM or lein
+dependencies are needed.
+
 ## Other scripts
 
 | Script | Purpose |

--- a/tools/validate_metadata.clj
+++ b/tools/validate_metadata.clj
@@ -15,6 +15,10 @@
 
 (def schema (edn/read-string (slurp "docs/metadata-schema.edn")))
 
+;; Hints built from the schema so error messages list the actual allowed values.
+(def types-hint    (str/join ", " (sort (:types schema))))
+(def maturity-hint (str/join "/"  (sort (:review-maturity schema))))
+
 (defn md-files []
   (->> (file-seq (io/file "docs"))
        (filter #(.isFile %))
@@ -55,28 +59,38 @@
         err! #(swap! errs conj %) warn! #(swap! warns conj %)
         fm (extract-frontmatter content)]
     (if-not fm
-      (err! "missing YAML frontmatter (file must start with `---` on line 1)")
+      (err! "no YAML frontmatter — add a `---` … `---` block at the very top of the file, with at least `type:` (see CLAUDE.md)")
       (let [data (try (yaml/parse-string fm)
-                      (catch Exception e (err! (str "YAML parse error: " (.getMessage e))) nil))]
+                      (catch Exception e
+                        (err! (str "frontmatter is not valid YAML: " (.getMessage e)
+                                   " — check indentation and that values with `:` or `#` are quoted"))
+                        nil))]
         (when data
           (let [t (:type data)]
             (cond
-              (or (nil? t) (str/blank? (str t))) (err! "missing required key `type`")
+              (or (nil? t) (str/blank? (str t)))
+              (err! (str "missing required key `type` — add `type:` set to one of: " types-hint
+                         " (extend docs/metadata-schema.edn to add a new one)"))
               (not (contains? (:types schema) (str t)))
-              (warn! (str "type \"" t "\" not in taxonomy"))))
+              (warn! (str "type \"" t "\" is not in the taxonomy (" types-hint
+                          ") — fix the value, or add it to :types in docs/metadata-schema.edn if intentional"))))
           (when-let [rm (:review_maturity data)]
             (when-not (contains? (:review-maturity schema) (str rm))
-              (err! (str "invalid review_maturity \"" rm "\" (expected one of L0–L4)"))))
+              (err! (str "invalid review_maturity \"" rm "\" — use one of " maturity-hint
+                         " (L0 AI-generated → L4 human-endorsed; see CLAUDE.md)"))))
           (doseq [k (:date-keys schema)]
             (when (contains? data k)
               (let [raw (raw-value fm k)]
                 (when-not (date-ok? raw)
-                  (err! (str (name k) " is not a valid YYYY-MM-DD date: " (pr-str (or raw (get data k)))))))))
+                  (err! (str (name k) ": " (pr-str (or raw (get data k)))
+                             " is not a valid date — use a zero-padded ISO date `YYYY-MM-DD`, e.g. 2026-06-16"
+                             " (pad single-digit months/days: 2026-6-6 → 2026-06-06)"))))))
           (when (and (contains? data :tags) (not (sequential? (:tags data))))
-            (warn! "`tags` should be a YAML list, e.g. [a, b]"))
+            (warn! "`tags` must be a YAML list in square brackets, e.g. tags: [data-model, edn-schema]"))
           (doseq [k (keys data)]
             (when-not (contains? (:known-keys schema) k)
-              (warn! (str "unknown key `" (name k) "` (typo, or add it to the schema)")))))))
+              (warn! (str "unknown key `" (name k) "` — check the spelling against the field list in CLAUDE.md,"
+                          " or add it to :known-keys in docs/metadata-schema.edn")))))))
     {:path path :errors @errs :warnings @warns}))
 
 (defn validate-bundle-root [content]
@@ -99,7 +113,8 @@
   (let [ctx (-> (:context-file schema) slurp json/parse-string (get "@context"))
         expected (remove (:context-exempt schema) (:known-keys schema))
         missing (remove #(contains? ctx (name %)) expected)]
-    (map #(str "docs/context.jsonld is missing a mapping for `" (name %) "`") missing)))
+    (map #(str "docs/context.jsonld is missing a JSON-LD mapping for `" (name %)
+               "` — add it under @context (e.g. \"" (name %) "\": \"dcterms:" (name %) "\")") missing)))
 
 (defn run []
   (let [files     (md-files)

--- a/tools/validate_metadata.clj
+++ b/tools/validate_metadata.clj
@@ -1,0 +1,133 @@
+(ns tools.validate-metadata
+  "Validate OKF + RDF YAML frontmatter across docs/ against docs/metadata-schema.edn.
+
+  Run from the repo root:
+
+      bb tools/validate_metadata.clj
+
+  Exits non-zero if any document has an error. Warnings do not fail the run.
+  See docs/rfcs/okf-metadata-rfc.md for the convention this enforces."
+  (:require [clojure.string :as str]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clj-yaml.core :as yaml]
+            [cheshire.core :as json]))
+
+(def schema (edn/read-string (slurp "docs/metadata-schema.edn")))
+
+(defn md-files []
+  (->> (file-seq (io/file "docs"))
+       (filter #(.isFile %))
+       (filter #(str/ends-with? (.getName %) ".md"))
+       (sort-by #(.getPath %))))
+
+(defn relpath [f] (str/replace (.getPath f) #"^\./" ""))
+
+(defn extract-frontmatter
+  "The YAML text between the opening `---` line and the next `---` line, or nil."
+  [content]
+  (when (str/starts-with? content "---\n")
+    (let [body (subs content 4)
+          idx  (str/index-of body "\n---")]
+      (when idx (subs body 0 idx)))))
+
+(defn raw-value
+  "The verbatim value text for key `k` from the raw frontmatter, unquoted.
+  We validate dates against this, not the parsed value: clj-yaml/SnakeYAML is
+  lenient and silently rolls 2026-13-45 over into a real Date, so the parsed
+  value can't catch a bad date — the authored text can."
+  [fm k]
+  (when-let [m (re-find (re-pattern (str "(?m)^" (name k) ":[ \\t]*(.+?)[ \\t]*$")) fm)]
+    (str/replace (second m) #"^['\"]|['\"]$" "")))
+
+(defn date-ok?
+  "True if the leading YYYY-MM-DD of `s` is a real calendar date (rejects
+  2026-13-45, requires zero-padding)."
+  [s]
+  (boolean
+   (and (string? s)
+        (try (java.time.LocalDate/parse (subs s 0 (min 10 (count s))))
+             true
+             (catch Exception _ false)))))
+
+(defn validate-concept [path content]
+  (let [errs (atom []) warns (atom [])
+        err! #(swap! errs conj %) warn! #(swap! warns conj %)
+        fm (extract-frontmatter content)]
+    (if-not fm
+      (err! "missing YAML frontmatter (file must start with `---` on line 1)")
+      (let [data (try (yaml/parse-string fm)
+                      (catch Exception e (err! (str "YAML parse error: " (.getMessage e))) nil))]
+        (when data
+          (let [t (:type data)]
+            (cond
+              (or (nil? t) (str/blank? (str t))) (err! "missing required key `type`")
+              (not (contains? (:types schema) (str t)))
+              (warn! (str "type \"" t "\" not in taxonomy"))))
+          (when-let [rm (:review_maturity data)]
+            (when-not (contains? (:review-maturity schema) (str rm))
+              (err! (str "invalid review_maturity \"" rm "\" (expected one of L0–L4)"))))
+          (doseq [k (:date-keys schema)]
+            (when (contains? data k)
+              (let [raw (raw-value fm k)]
+                (when-not (date-ok? raw)
+                  (err! (str (name k) " is not a valid YYYY-MM-DD date: " (pr-str (or raw (get data k)))))))))
+          (when (and (contains? data :tags) (not (sequential? (:tags data))))
+            (warn! "`tags` should be a YAML list, e.g. [a, b]"))
+          (doseq [k (keys data)]
+            (when-not (contains? (:known-keys schema) k)
+              (warn! (str "unknown key `" (name k) "` (typo, or add it to the schema)")))))))
+    {:path path :errors @errs :warnings @warns}))
+
+(defn validate-bundle-root [content]
+  (let [errs (atom []) err! #(swap! errs conj %)
+        fm (extract-frontmatter content)]
+    (if-not fm
+      (err! "bundle root index.md must declare okf_version in frontmatter")
+      (let [data (yaml/parse-string fm)
+            extra (disj (set (keys data)) :okf_version)]
+        (when-not (= (str (:okf_version data)) (:okf-version schema))
+          (err! (str "okf_version must be \"" (:okf-version schema) "\"")))
+        (when (seq extra)
+          (err! (str "index.md frontmatter may contain only okf_version; found also "
+                     (str/join ", " (map name extra)))))))
+    {:path (:bundle-root schema) :errors @errs :warnings []}))
+
+(defn validate-context
+  "Every known key (minus :context-exempt) must have a JSON-LD @context mapping."
+  []
+  (let [ctx (-> (:context-file schema) slurp json/parse-string (get "@context"))
+        expected (remove (:context-exempt schema) (:known-keys schema))
+        missing (remove #(contains? ctx (name %)) expected)]
+    (map #(str "docs/context.jsonld is missing a mapping for `" (name %) "`") missing)))
+
+(defn run []
+  (let [files     (md-files)
+        reserved? #(contains? (:reserved-files schema) (.getName %))
+        grouped   (group-by reserved? files)
+        concepts  (get grouped false [])
+        reserved  (get grouped true [])
+        results   (mapv #(validate-concept (relpath %) (slurp %)) concepts)
+        ;; only docs/index.md gets bundle-root treatment; other reserved files are noted
+        root-res  (when-let [root (first (filter #(= (relpath %) (:bundle-root schema)) reserved))]
+                    (validate-bundle-root (slurp root)))
+        all       (cond-> results root-res (conj root-res))
+        ctx-warns (validate-context)]
+    (doseq [{:keys [path errors warnings]} (sort-by :path all)]
+      (println (if (seq errors) "FAIL" "PASS") path)
+      (doseq [e errors]   (println "    ERROR:" e))
+      (doseq [w warnings] (println "    warn: " w)))
+    (doseq [w ctx-warns] (println "FAIL docs/context.jsonld\n    ERROR:" w))
+    (let [err-files (count (filter #(seq (:errors %)) all))
+          n-warn    (reduce + (map #(count (:warnings %)) all))
+          n-ctx     (count ctx-warns)]
+      (println)
+      (printf "%d documents checked · %d with errors · %d warnings · %d context gaps\n"
+              (count all) err-files n-warn n-ctx)
+      (if (or (pos? err-files) (pos? n-ctx))
+        (do (println "FAILED") 1)
+        (do (println "OK") 0)))))
+
+;; Run when invoked as a script (bb tools/validate_metadata.clj), not when required.
+(when (= *file* (System/getProperty "babashka.file"))
+  (System/exit (run)))


### PR DESCRIPTION
## Context

PR #71 adopted the OKF + RDF YAML-frontmatter convention but left it unenforced. This adds the **Enforcement** rung of the [reliability ratchet](docs/glossary.md#r) (`LLM → REPL → Library → Enforcement`). Follows #71.

## Problem

Without a deterministic check, the convention degrades to documentation: nothing catches a missing `type`, an out-of-range `review_maturity`, or a malformed date before it lands.

## Solution

`tools/validate_metadata.clj` (babashka) validates every non-reserved `.md` under `docs/` against `docs/metadata-schema.edn` (the editable source of truth): frontmatter present, non-empty `type`, `review_maturity ∈ {L0..L4}`, valid `YYYY-MM-DD` dates, and `context.jsonld` coverage of every known key.

**One validator, three surfaces** (so they can't drift):
- **git pre-commit hook** — `.githooks/pre-commit`, enabled via `bin/install-hooks` (fast local feedback)
- **`lein test`** — `clojuredocs.metadata-test` shells out to the validator (local suite)
- **CI** — `.github/workflows/docs-metadata.yml` (authoritative remote gate, fast `bb` step)

Error messages are **actionable** and generated from the schema (e.g. a bad date prints `use a zero-padded YYYY-MM-DD, e.g. 2026-06-16`; a missing `type` lists the taxonomy), so contributors get told how to fix it.

Validator passes all docs (exit 0). Two notable points surfaced during review:
- The `/research-review` claims-auditor caught that "ISO 8601 dates" overstated a shape-only regex — and clj-yaml/SnakeYAML *silently rolls `2026-13-45` over* into a valid date. The validator now parses the **raw authored text**, so impossible/unpadded dates are actually rejected. Logged in `docs/rfcs/okf-metadata-rfc_research-review_run_2.md`.
- `metadata-schema.edn` is the single source of truth: adding a `type` there updates validation **and** the error hints.

<details>
<summary>Father Watson Questions</summary>

- **What do we know?** The convention is adopted (#71) but nothing enforces it; bad metadata can land silently.
- **What do we need to know?** Whether to require hook installation in onboarding.
- **Where are we?** Validator + schema + three surfaces implemented; all docs pass; errors are actionable.
- **Where are we going?** This closes the Enforcement rung of the [reliability ratchet](docs/glossary.md#r). Remaining frontmatter migration for the `feat/43` docs happens when that branch lands.

</details>

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>