### PR TITLE
feat: add session-discipline skills (grill-me, handoff, ratchet)

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -9,6 +9,7 @@ skill is a directory with a `SKILL.md`. User-invocable skills are triggered with
 | [`grill-me`](grill-me/SKILL.md) | Alignment-first interview before building; writes a plan/PRD to disk. |
 | [`handoff`](handoff/SKILL.md) | Write a resumable state-of-work note so you can `/clear` instead of `/compact`. |
 | [`ratchet`](ratchet/SKILL.md) | Harden an informal check toward enforcement: LLM → REPL → Library → Enforcement. |
+| [`narrate`](narrate/SKILL.md) | Reframe a finished session as a short story for a human (recap, retro, demo). |
 
 ## Session discipline
 
@@ -20,4 +21,4 @@ reliability-ratchet convention (see the [glossary](../../docs/glossary.md)).
 
 A typical loop: `/grill-me` to align and write a plan → implement one vertical slice → ship → `/handoff` →
 `/clear` → resume from the handoff for the next slice. Reach for `/ratchet` whenever a check starts repeating
-by hand.
+by hand, and `/narrate` to recap a finished session as a short, human-readable story.

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,0 +1,23 @@
+# Skills
+
+Project-level [Claude Code skills](https://docs.claude.com/en/docs/claude-code/skills) for this repo. Each
+skill is a directory with a `SKILL.md`. User-invocable skills are triggered with `/<name>`.
+
+| Skill | Use |
+|---|---|
+| [`issue-writer`](issue-writer/SKILL.md) | Draft GitHub issues that diagnose rather than prescribe. |
+| [`grill-me`](grill-me/SKILL.md) | Alignment-first interview before building; writes a plan/PRD to disk. |
+| [`handoff`](handoff/SKILL.md) | Write a resumable state-of-work note so you can `/clear` instead of `/compact`. |
+| [`ratchet`](ratchet/SKILL.md) | Harden an informal check toward enforcement: LLM → REPL → Library → Enforcement. |
+
+## Session discipline
+
+`grill-me`, `handoff`, and `ratchet` operationalize the "smart zone" argument for disciplined AI coding —
+reasoning degrades as context grows, so front-load alignment, externalize state to disk, and start fresh
+rather than dragging a long, degrading context forward. They are adapted from
+[Matt Pocock's AI-coding workshop](https://finance.biggo.com/news/e7209c094224b09c) and this repo's own
+reliability-ratchet convention (see the [glossary](../../docs/glossary.md)).
+
+A typical loop: `/grill-me` to align and write a plan → implement one vertical slice → ship → `/handoff` →
+`/clear` → resume from the handoff for the next slice. Reach for `/ratchet` whenever a check starts repeating
+by hand.

--- a/.github/skills/grill-me/SKILL.md
+++ b/.github/skills/grill-me/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: grill-me
+description: 'Alignment-first interview before building. Claude interviews you to surface requirements, constraints, edge cases, and acceptance criteria, then writes a short plan/PRD to disk that survives a /clear. Use at the start of any non-trivial task, before writing code.'
+user_invocable: true
+arguments:
+  - name: topic
+    description: The task or feature to align on (optional; Claude will ask if omitted)
+    required: false
+---
+
+# Grill Me
+
+Front-load alignment. Before any implementation, interview the developer until the task is concrete enough to build without guessing, then write the result to disk as a plan a fresh session can pick up.
+
+This is the *alignment phase* from Matt Pocock's AI-coding workshop: the model interviews the developer rather than the reverse, because the expensive failures come from building the wrong thing confidently, not from typing slowly.
+
+## When to use
+
+- Starting a non-trivial feature, refactor, or investigation
+- A request is underspecified and you can feel multiple reasonable interpretations
+- Before kicking off an autonomous/background implementation, so it has a spec to work from
+
+## Procedure
+
+1. **Establish the goal.** If `$ARGUMENTS.topic` was given, restate it in one sentence and confirm. Otherwise ask what we're building and why.
+2. **Interview in focused rounds.** Ask high-leverage questions a few at a time (use `AskUserQuestion` for genuine choices), and let each answer shape the next question. Do not dump a 40-item quiz. Cover, as relevant:
+   - **Problem / why** — what's broken or missing; who feels it.
+   - **Users / stakeholders** — who consumes this; whose sign-off matters.
+   - **Scope boundaries** — explicitly in-scope vs out-of-scope. Force the line.
+   - **Constraints** — tech, dependencies, time, compatibility, conventions to honor.
+   - **Interfaces & data shapes** — inputs, outputs, schemas, the boundary contracts.
+   - **Edge cases & failure modes** — what happens when inputs are bad, empty, huge, concurrent.
+   - **Acceptance criteria** — how we'll know it's done and correct (tests, observable behavior).
+   - **Risks & unknowns** — what we don't know yet; what could invalidate the approach.
+3. **Know when to stop.** Stop when the picture is concrete enough to implement without guessing. Don't pad with questions whose answers wouldn't change the work. Surface remaining unknowns explicitly rather than inventing answers.
+4. **Write the plan to disk.** Produce a short markdown plan/PRD the developer can read and a future session can resume from. Default to a `plans/` directory if one exists, else a file the user names (e.g. `./<slug>-plan.md`). If the repo has documentation conventions (e.g. required frontmatter under `docs/`), follow them. Sections:
+   - **Goal** (one or two sentences) · **Context / why** · **In scope** / **Out of scope** · **Constraints** · **Interfaces & data** · **Acceptance criteria** · **Open questions** · **Slices** (optional ordered list of vertically-sliced steps, each independently shippable).
+5. **Hand off.** Tell the user the file path and that it survives a `/clear` — a fresh session can start from it (pair with `/handoff`).
+
+## Key constraints
+
+- **Do not start implementing.** This skill ends at a written plan. Building is a separate, ideally fresh, session.
+- **Never fabricate an answer.** If the user defers or doesn't know, record it under Open questions — an honest unknown is more useful than a confident guess.
+- **Fewer, sharper questions beat a long quiz.** Optimize for the questions whose answers most change the work.
+- **The plan is the artifact**, not the conversation. Keep it tight and decision-dense.

--- a/.github/skills/handoff/SKILL.md
+++ b/.github/skills/handoff/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: handoff
+description: 'Write a structured state-of-work note to disk so you can /clear and resume in a fresh context instead of using /compact. Use at phase boundaries or when the session is long enough that reasoning quality is degrading (~100K tokens, the "smart zone" ceiling).'
+user_invocable: true
+arguments:
+  - name: path
+    description: Where to write the handoff note (optional; defaults to a handoffs directory)
+    required: false
+---
+
+# Handoff
+
+Capture the state of the work to disk so the conversation can be thrown away. Then `/clear` and resume in a fresh, full-quality context — instead of `/compact`, which keeps you in one ever-degrading window.
+
+The premise (from Matt Pocock's AI-coding workshop): reasoning degrades as context grows, so a long session is a *liability*, not an asset. The fix is to externalize state to files and start fresh. A summary kept in-context still carries the rot; a note on disk does not.
+
+## When to use
+
+- At a natural phase boundary (a slice is done, a PR is shipped).
+- When the session is long and answers are getting vaguer or repetitive.
+- Before stepping away, so the work can resume cleanly later or by someone else.
+- Any time you're tempted to `/compact` — handoff then `/clear` instead.
+
+## Procedure
+
+1. **Choose the path.** Use `$ARGUMENTS.path` if given; else default to `.claude/handoffs/<YYYY-MM-DD>-<slug>.md` (create the directory) or a repo-appropriate location. Prefer a stable, discoverable path.
+2. **Write only what a fresh session needs.** The reader will re-read the actual files, so point at ground truth rather than reproducing it. Capture:
+   - **Task / goal** — the objective, with links to the issue, PRD, or `/grill-me` plan.
+   - **Current state** — what's done, what's in progress, and crucially what's *verified* vs *unverified*.
+   - **Ground-truth pointers** — the source-of-truth files, tests, and key paths to read first. Paths, not paraphrases.
+   - **Next steps** — the immediate next actions, concrete enough to act on cold.
+   - **Open questions / pending decisions** — anything unresolved.
+   - **Git state** — current branch, last commit, uncommitted changes, any stacked-PR context.
+   - **Gotchas** — context that isn't obvious from the files (a non-obvious constraint, a dead end already ruled out, a flaky step).
+3. **Keep it tight.** A handoff is a map, not a transcript. If you're reproducing file contents, stop and link the file instead.
+4. **Be honest about what's unverified.** Mark claims that haven't been checked against a running system / tests, so the next session re-verifies rather than trusting them.
+5. **Close out.** Tell the user it's safe to `/clear` now, and that resuming means: start a fresh session and read the handoff file first.
+
+## Key constraints
+
+- **Do not dump the conversation.** Capture decisions and state, not narrative history.
+- **Point to files; don't transcribe them.** Ground truth lives on disk; the note routes the reader to it.
+- **Don't overstate completion.** "Done and verified" and "written but untested" are different — say which.
+- **One handoff = one resumable unit.** If two unrelated threads are open, write two notes.

--- a/.github/skills/narrate/SKILL.md
+++ b/.github/skills/narrate/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: narrate
+description: 'Reframe the current work session as a short narrative for a human, fitting a classic story arc (hero''s journey, man in a hole, three-act, Vonnegut shapes, story circle). Use for a recap, retro, demo, or changelog where a memorable story beats a status list. The arc shapes emphasis; the facts stay real; keep it brief.'
+user_invocable: true
+arguments:
+  - name: arc
+    description: 'Story arc (optional; auto-fit to the session if omitted). e.g. heros-journey, man-in-a-hole, three-act, quest, tragedy, rags-to-riches.'
+    required: false
+  - name: tone
+    description: 'Optional voice — epic, fable, noir, dry-technical, children''s-book. Default: warm, literary, grounded.'
+    required: false
+---
+
+# Narrate
+
+Turn the session into a short story a human will remember. The human-facing complement to `/handoff`: handoff is the map the next session reads; narrate is the story a person reads.
+
+## When to use
+
+A standup, retro, demo, Slack recap, or changelog where a narrative lands better than bullets — or to close out a long session.
+
+## Procedure
+
+1. **Find the spine.** From the session context, pull the real beats: goal, the setback(s), the turning point, the resolution. Name actual artifacts (files, PRs, bugs) — they become the story's objects.
+2. **Pick the arc** (`$ARGUMENTS.arc`, else auto-fit to the session's real shape):
+   - **Man in a hole** — fine → broke → fixed. The default for a bug/incident.
+   - **Hero's journey / story circle** — set out, faced trials, returned changed. For an ambitious build.
+   - **Three-act** — setup → confrontation → resolution. General-purpose default.
+   - **Quest** — one target, escalating obstacles. For a focused hunt.
+   - **Tragedy / Icarus** — rise then fall. Use it honestly when a session ended worse than it began.
+   State the arc and a one-line reason it fits.
+3. **Tell it, short.** Map the beats to the arc and write it in the requested `tone` (default: warm, grounded). Let real artifacts carry the imagery — the failing test is the dragon, the source-of-truth file the talisman.
+4. **Close with a true moral** — one line that is genuinely a lesson of *this* session.
+
+## Key constraints
+
+- **Succinct and digestible.** Default to ~120–200 words: a tight opening, two or three beats, a one-line moral. Shorter than the work it describes. Expand only if asked.
+- **Faithful to events.** The arc shapes emphasis and order, never facts. No invented drama or triumph that didn't happen.
+- **Honest endings.** If it ended unresolved, use an arc that fits (cliffhanger, *still in the hole*). No fake happy ending.
+- **No-arc is valid.** A typo fix gets one sentence, not a hero's journey.
+- **It's framing, not the record.** Point to the decision log / handoff for what literally happened.

--- a/.github/skills/ratchet/SKILL.md
+++ b/.github/skills/ratchet/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: ratchet
+description: 'Harden an informal finding, convention, or manual check into progressively more deterministic enforcement: LLM → REPL → Library → Enforcement. Use when you catch yourself repeating a check by hand, or relying on the model to "remember" a rule.'
+user_invocable: true
+arguments:
+  - name: finding
+    description: The informal finding, rule, or check to harden (optional; Claude will ask)
+    required: false
+---
+
+# Ratchet
+
+Move a thing you currently trust on vibes one rung up the reliability ladder, toward something a machine enforces. LLMs will happily stay at rung one forever — restating a rule in prose every time — so the human has to decide when to advance.
+
+The ladder: **LLM → REPL → Library → Enforcement.**
+
+- **LLM** — the rule lives in a prompt, a doc, or your head. Re-checked by re-reasoning; drifts silently.
+- **REPL** — you can reproduce the check in a snippet/command. Repeatable, but run by hand.
+- **Library** — the check is a function, schema, or data file. A deterministic artifact, importable and testable.
+- **Enforcement** — the artifact is wired into a test, lint, CI job, or git hook that *fails* on violation. Correctness is now guarded, not hoped for.
+
+Documentation is for humans deciding whether to adopt; enforcement is for ensuring correctness. They are not substitutes.
+
+## When to use
+
+- You've consulted the same convention by hand more than once.
+- You're relying on the model to remember a rule across turns or sessions.
+- A finding was just verified in a REPL and risks rotting back into prose.
+- A review keeps catching the same class of mistake.
+
+## Procedure
+
+1. **State the finding** (`$ARGUMENTS.finding` or ask) and **locate its current rung** — is it prose, a one-off snippet, an artifact, or already enforced?
+2. **Name the next rung and the move to reach it:**
+   - LLM → REPL: write a reproducible snippet/command that decides it (pass/fail), not a paragraph describing it.
+   - REPL → Library: extract the check into a function, schema, or data file — a single deterministic source of truth.
+   - Library → Enforcement: wire it into a test / lint rule / CI step / pre-commit hook that fails on violation, and emit an actionable message ("bad date format — try padding to YYYY-MM-DD").
+3. **Recommend the highest rung worth reaching now** — not always the top. Weigh cost vs. how often the check runs and how expensive a miss is. A one-time check may stop at REPL; a load-bearing invariant should reach Enforcement.
+4. **Offer to implement the next step** (with approval). Leave a clear trail: what was hardened, from which rung to which, and where the artifact lives.
+5. **Watch for the smell:** if you keep consulting a reference to apply a rule correctly, that's the signal to harden it into a deterministic check rather than document it more thoroughly.
+
+## Key constraints
+
+- **Advance one rung at a time** unless a higher jump is clearly cheap. Each rung must actually work before the next.
+- **Enforcement needs a good error message.** A failing check that doesn't say why just moves the guessing.
+- **Don't over-ratchet.** Not every observation deserves a CI gate; match the rung to the stakes.
+- **Prefer one source of truth.** When you reach Library/Enforcement, the test and the doc should reference the same artifact, not restate the rule independently.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -204,6 +204,43 @@ Resolved — the crash data came in and supports it; kept permanently per the [2
 
 ---
 
+## 2026-06-16 — Experiment with session-discipline skills from the "smart zone" framing
+
+### Status
+Decided (experimental)
+
+### Context
+- Read [Matt Pocock's AI-coding workshop](https://finance.biggo.com/news/e7209c094224b09c) on the "smart zone": model reasoning degrades past ~100K tokens, so a long context is a liability. His prescriptions are classic engineering — front-load alignment ("grill me"), externalize state, review in a *fresh* context, decompose into vertical slices, and avoid `/compact` in favor of fresh starts.
+- The session that produced tonight's work ran on 1M-context Opus *and* used `/compact` — against his specific advice — even though the artifacts (EDN source of truth, deterministic generators, decision log, errata) embodied his deeper point: anchor on ground truth on disk, not the model's working memory.
+- We already hold a [reliability-ratchet](glossary.md) convention (LLM → REPL → Library → Enforcement), which is the same instinct applied to checks rather than sessions.
+
+### Decision
+- Translate the session discipline into Claude Code skills and adopt them as an experiment: `/grill-me` (alignment interview → plan on disk), `/handoff` (resumable state note so you can `/clear` instead of `/compact`), and `/ratchet` (harden a check up the ladder). Run the loop *grill → implement one slice → ship → handoff → clear → resume* and see whether it improves output quality and review burden.
+- Skills committed in [PR #74](https://github.com/nubank/clojuredocs/pull/74) and installed to `~/.claude/skills/` for cross-repo use.
+
+### Rationale
+- The mechanics matter less than the substrate: if state lives in files, throwing away a degrading context is cheap and safe. The skills make that the default rather than an afterthought.
+- A fresh-context reviewer catches what the implementer's context cannot — already validated this session, where independent audit sub-agents caught real fabrications.
+- It is a low-cost experiment: skills are additive, reversible, and prune-able if a habit doesn't pay off.
+
+### Alternatives Considered
+- Keep long sessions + `/compact` — the status quo; carries the degrading context forward, the failure mode the article names.
+- Adopt Pocock's full tooling (Sand Castle / the "Ralph loop") wholesale — heavier and TypeScript-oriented; the Claude Code equivalents (subagents, worktrees, background tasks) cover most of it without new infrastructure.
+- Do nothing / treat it as reading only — forgoes the cheap chance to harden the workflow.
+
+### Impacts and Risks
+- Behavioral change: the loop competes with the "keep momentum across phases" habit. Reconciliation — momentum should be carried by files, not by context length; a phase boundary becomes a natural `/handoff` + `/clear`.
+- The skills are experimental and may be revised or dropped. `/slice` and `/fresh-review` were considered and deferred.
+- Adapting an external framework: claims about the ~100K "smart zone" are the author's; we are testing the workflow, not certifying the number.
+
+### Links
+- [PR #74](https://github.com/nubank/clojuredocs/pull/74)
+- [Matt Pocock on AI coding's "smart zone"](https://finance.biggo.com/news/e7209c094224b09c)
+- [.github/skills/README.md](../.github/skills/README.md)
+- [glossary — reliability ratchet](glossary.md)
+
+---
+
 ## 2026-06-16 — Enforce doc metadata with a bb validator (three surfaces)
 
 ### Status


### PR DESCRIPTION
## Context

Three Claude Code skills that operationalize disciplined AI coding — the "smart zone" argument that model reasoning degrades as context grows, so you should front-load alignment, externalize state to disk, and start fresh rather than drag a long, degrading context forward. Adapted from [Matt Pocock's AI-coding workshop](https://finance.biggo.com/news/e7209c094224b09c) and this repo's own reliability-ratchet convention.

## Problem

Long sessions and `/compact` keep work inside an ever-degrading context. Alignment is usually skipped, so we build the wrong thing confidently. Conventions live in prose and rot.

## Solution

New skills under `.github/skills/` (alongside `issue-writer`):

- **`/grill-me`** — alignment-first interview before building; writes a plan/PRD to disk that survives a `/clear`.
- **`/handoff`** — write a resumable state-of-work note so you can `/clear` and resume in a fresh context instead of `/compact`.
- **`/ratchet`** — harden an informal check toward enforcement: LLM → REPL → Library → Enforcement.

A `README` indexes them and credits the source. The intended loop: `/grill-me` → implement one slice → ship → `/handoff` → `/clear` → resume.

Also installed to `~/.claude/skills/` for cross-repo use (not tracked here).

<details>
<summary>Father Watson Questions</summary>

- **What do we know?** These three map cleanly to the workshop's principles and to our existing ratchet convention.
- **What do we need to know?** Whether the team wants a code-focused `/fresh-review` and a `/slice` skill too (proposed, deferred for now).
- **Where are we?** Skills written, installed locally, confidentiality-checked.
- **Where are we going?** Adopt the grill → slice → ship → handoff → clear loop as the default rhythm; harden repeated checks with `/ratchet`.
</details>