### PR TITLE
fix: prevent search handlers from corrupting state via navigate-to re…

### DIFF
--- a/src/cljs/clojuredocs/mods/search.cljs
+++ b/src/cljs/clojuredocs/mods/search.cljs
@@ -356,10 +356,12 @@
                                (or (:href res)
                                    (util/var-path
                                      (:ns res)
-                                     (:name res)))))
+                                     (:name res))))
+                             nil)
                ::var-search (fn [state text]
                               (util/navigate-to
-                                (str "/search?q=" (util/url-encode text))))})]
+                                (str "/search?q=" (util/url-encode text)))
+                              nil)})]
 
     (when-not (empty? (sel :.search-widget))
       (swap! !state assoc :search-focused? true))

--- a/src/cljs/nsfw/ops.cljs
+++ b/src/cljs/nsfw/ops.cljs
@@ -127,7 +127,18 @@
                 !state
                 ctx)
 
-    :else (when res (reset! !state res))))
+    ;; A terminal handler value is the new state, which must be a map.
+    ;; Guard against non-map returns: a handler whose last expression is a
+    ;; side-effecting call (e.g. util/navigate-to, which returns the string
+    ;; from aset) would otherwise reset! the state atom to that value,
+    ;; corrupting it and crashing every later handler. Warn instead of
+    ;; silently swallowing — a non-map here is always a handler bug.
+    :else (cond
+            (map? res) (reset! !state res)
+            res (println
+                  "[nsfw.ops] handle-step: ignoring non-map handler return value; state left unchanged."
+                  "Handlers that end in a side-effecting call (e.g. util/navigate-to) must return nil. Got:"
+                  (pr-str res)))))
 
 (defn gen-lock-step [handler]
   (fn [{:keys [!state] :as ctx} params]


### PR DESCRIPTION
## Context

fix for #46 

I was able to reproduce the in chrome, safari and mobile safari. If you are running the dev figwheel the issue does not appear due to live reloading hiding the issue 

I was able to confirm this fix works on web chrome and web safari

## Problem

The search handlers ::ac-select and ::var-search called util/navigate-to, which uses aset to set window.location.href. aset returns the URL string it set. That string bubbled back through [handle-step](https://github.com/nubank/clojuredocs/blob/2cccad9107e5336bd9aef16c65c96c512c65066f/src/cljs/nsfw/ops.cljs#L130), which treated it as the new app state and reset! the state atom from a map to a string. After that, any interaction with the search box crashed because handlers tried to assoc/merge onto a string instead of a map.

https://github.com/user-attachments/assets/b9d129f9-ffed-4659-a3a5-00b61bb2b981


## Solution

The fix: return nil from both handlers so handle-step leaves the state alone.

---

<details>
<summary>Father Watson Questions (diagnostic framing)</summary>

### What do we know?

<!-- Established facts. Evidence, code references, prior conversation. -->

### What do we need to know?

<!-- Open questions. Investigations not yet done. Decisions deferred to maintainers. -->

### Where are we?

<!-- Current state. The baseline before this change. -->

### Where are we going?

<!-- Desired outcomes, in user-facing terms. -->

</details>
