### PR TITLE
fix: throttle in-process export to weekly (#76)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,7 +4,7 @@ title: Decision Log
 description: Design and architecture decisions; lightweight alternative to full ADRs.
 tags: [decisions, architecture, living-document]
 created: 2026-04-29
-modified: 2026-06-16
+modified: 2026-06-24
 creator: L. Jordan Miller
 ai_assisted: "Claude Opus 4.8 via Claude Code"
 review_maturity: L4
@@ -14,6 +14,37 @@ review_note: Human-endorsed — decisions are the team's; AI-drafted rationale i
 # Decision Log
 
 Document design and architecture decisions. Lightweight alternative to full ADRs.
+
+---
+
+## 2026-06-24 — Throttle in-process export to weekly (diagnostic for #76)
+
+### Status
+Provisional — a diagnostic experiment, not a settled decision. Revisit once the crash data is in.
+
+### Context
+- [Issue #76](https://github.com/nubank/clojuredocs/issues/76): Matomo shows a client-side crash regression beginning the week of **2026-05-11**. Crash occurrences were flat at 0 all year, then jumped to ~9–14% of visits and stayed elevated through June.
+- That is the same week PR #39 shipped the in-process scheduled export (see the 2026-05-11 entry below), which runs `export/run-export` **every 6 hours** (4×/day) starting on boot.
+- Crashes cluster on the highest-traffic page (homepage `/`, ~5% pageview crash rate) and thin out on individual var pages — the shape of a server-wide intermittent degradation (crashes ∝ traffic), consistent with a recurring job rather than one broken page.
+- Causation is **unconfirmed**: a same-week tracking-script change, dependency bump, or browser-API change could equally explain it.
+
+### Decision
+- Reduce the recurring export cadence from every 6 hours to **once per week** (`export-interval-hours` 6 → `(* 24 7)` = 168) in `start-app`.
+- Keep the initial delay at `0`, so each deploy still refreshes the export — only the recurring interval changes.
+
+### Rationale
+- Smallest reversible change that isolates a single variable. If the weekly crash rate collapses toward ~0, the in-process export is implicated; if it stays elevated, the export is exonerated and we pivot to the other candidates.
+- A one-line flip back to `6` reverts it.
+
+### Impacts and Risks
+- `clojuredocs-export.json` refreshes roughly weekly plus on each deploy, so it can be staler between deploys. Acceptable for a short diagnostic window; the editor-plugin consumers tolerate slightly stale examples.
+- This does not fix root cause — it is an experiment. The issue stays open; root-cause confirmation and a regression guard are follow-ups.
+
+### Links
+- [Issue #76](https://github.com/nubank/clojuredocs/issues/76)
+- [Issue #38](https://github.com/nubank/clojuredocs/issues/38)
+- [PR #39](https://github.com/nubank/clojuredocs/pull/39)
+- [src/clj/clojuredocs/main.clj](src/clj/clojuredocs/main.clj)
 
 ---
 
@@ -66,6 +97,8 @@ machine-parseability.
 ---
 
 ## 2026-05-11 — Schedule export JSON regeneration in-process
+
+> **Update 2026-06-24:** the 6-hour interval below was throttled to weekly pending the #76 crash investigation — see the [2026-06-24 entry](#2026-06-24--throttle-in-process-export-to-weekly-diagnostic-for-76) above. The text below records the original decision.
 
 ### Status
 Decided

--- a/src/clj/clojuredocs/main.clj
+++ b/src/clj/clojuredocs/main.clj
@@ -82,7 +82,7 @@
 
 (def ^:private export-path "resources/public/clojuredocs-export.json")
 
-(def ^:private export-interval-hours 6)
+(def ^:private export-interval-hours (* 24 7)) ; weekly — diagnostic throttle for #76 (was 6)
 
 (defn- run-scheduled-export []
   (try


### PR DESCRIPTION
## Context

[Issue #76](https://github.com/nubank/clojuredocs/issues/76): Matomo shows a client-side crash regression beginning the week of **2026-05-11** — crash occurrences were flat at 0 all year, then jumped to ~9–14% of visits and stayed elevated through June. That is the same week [PR #39](https://github.com/nubank/clojuredocs/pull/39) shipped the in-process scheduled export. Crashes cluster on the highest-traffic page (homepage `/`, ~5% pageview crash rate) and thin out on individual var pages — the shape of a server-wide intermittent degradation (crashes ∝ traffic), not one broken page.

## Problem

PR #39 runs `export/run-export` **every 6 hours** (4×/day) in-process via a `ScheduledExecutorService` in `start-app`. The leading hypothesis in #76 is that this recurring regeneration degrades responses and triggers the client-side crashes. **Causation is unconfirmed** — a same-week tracking-script change, dependency bump, or browser-API change could equally explain it.

## Solution

Reduce the recurring cadence from 6h to **weekly** (`export-interval-hours` `6` → `(* 24 7)` = 168). The initial delay stays `0`, so each deploy still refreshes the export — only the recurring interval changes.

This isolates a single variable. If the weekly crash rate collapses toward ~0, the export job is implicated; if it stays elevated, the export is exonerated and we pivot to the other same-week candidates. A one-line flip back to `6` reverts it.

`Refs #76` — this is a **diagnostic experiment, not a root-cause fix**, so it does not close the issue. Documented as a Provisional entry in [docs/decisions.md](../blob/hotfix/76-export-interval/docs/decisions.md), with a forward note on the original 2026-05-11 decision.

<details>
<summary>Father Watson Questions</summary>

- **What do we know?** The 6h in-process export and the crash spike began the same week; crashes track traffic, which fits a recurring server-side degradation.
- **What do we need to know?** Whether the crash rate actually drops once the cadence is weekly — and the actual Matomo crash messages/stack traces for the period.
- **Where are we?** Diagnostic shipped: one variable changed, everything else held constant.
- **Where are we going?** Watch the crash rate for 1–2 weeks. If it falls, confirm root cause and harden the export (out-of-process or guarded). If it doesn't, rule out #39 and investigate the other same-week changes.

</details>