### PR TITLE
docs: log prod-host maintenance decision (#76 side quest)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -29,7 +29,7 @@ Decided — applied by hand on the prod host during the #76 deploy session. Not 
 
 ### Decision
 - **Reboot** to activate the pending kernel + glibc updates; boot into `6.17.0-1017-aws`.
-- **Cap journald at `SystemMaxUse=200M`** in `/etc/systemd/journald.conf` (previously unbounded at the ~10% default).
+- **Cap journald at `SystemMaxUse=200M`** in `/etc/systemd/journald.conf` (previously using journald's default cap, ~10% of disk).
 - **Purge superseded kernels** after reboot (`6.14.0-1011-aws`) as routine hygiene.
 - **Keep reboots manual** — do not enable `Unattended-Upgrade::Automatic-Reboot`.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -35,7 +35,7 @@ Decided — applied by hand on the prod host during the #76 deploy session. Not 
 
 ### Rationale
 - *Manual reboots:* this is a single-box prod site whose service cold-starts via `lein run` (slow, ~45–60s). A surprise automated reboot means unannounced downtime; a human choosing a low-traffic window is safer for one host than a 2 a.m. auto-reboot.
-- *Journald cap:* the journal was the only meaningfully reclaimable space on a tight volume. An explicit 200M cap makes the one-time `journalctl --vacuum-size` permanent so it can't silently regrow to ~686M — the reliability ratchet (one-off cleanup → config-enforced bound).
+- *Journald cap:* the journal was the only meaningfully reclaimable space on a tight volume. An explicit 200M cap makes the one-time `journalctl --vacuum-size=200M` permanent so it can't silently regrow to ~686M — the reliability ratchet (one-off cleanup → config-enforced bound).
 - *Patching:* deferred kernel + glibc updates are a standing security exposure; activating them was overdue.
 
 ### Impacts and Risks

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -17,6 +17,38 @@ Document design and architecture decisions. Lightweight alternative to full ADRs
 
 ---
 
+## 2026-06-24 — Prod host: patch kernel/glibc, cap journald, keep reboots manual
+
+### Status
+Decided — applied by hand on the prod host during the #76 deploy session. Not captured in any IaC; this entry is the only record (see Risks).
+
+### Context
+- Deploying the [#76](https://github.com/nubank/clojuredocs/issues/76) hotfix surfaced three host warnings in the SSH banner: a pending system restart, `/` at **87%** of a small **6.8G** root volume, and 61 available updates.
+- `reboot-required.pkgs` listed accumulated kernel images plus `libc6` (glibc) — security updates that `unattended-upgrades` had installed but never activated, because the host was never rebooted. It was running `6.14.0-1011-aws`; the newest installed kernel was `6.17.0-1017-aws`.
+- The disk pressure was **not** old kernels (only one was removable). `du` showed `/usr` (3.4G, mostly JVM + kernel modules) and `/var` (2.2G) as the weight; the one genuinely reclaimable chunk was an overgrown systemd journal (~686M — journald's default cap is ~10% of disk).
+
+### Decision
+- **Reboot** to activate the pending kernel + glibc updates; boot into `6.17.0-1017-aws`.
+- **Cap journald at `SystemMaxUse=200M`** in `/etc/systemd/journald.conf` (previously unbounded at the ~10% default).
+- **Purge superseded kernels** after reboot (`6.14.0-1011-aws`) as routine hygiene.
+- **Keep reboots manual** — do not enable `Unattended-Upgrade::Automatic-Reboot`.
+
+### Rationale
+- *Manual reboots:* this is a single-box prod site whose service cold-starts via `lein run` (slow, ~45–60s). A surprise automated reboot means unannounced downtime; a human choosing a low-traffic window is safer for one host than a 2 a.m. auto-reboot.
+- *Journald cap:* the journal was the only meaningfully reclaimable space on a tight volume. An explicit 200M cap makes the one-time `journalctl --vacuum-size` permanent so it can't silently regrow to ~686M — the reliability ratchet (one-off cleanup → config-enforced bound).
+- *Patching:* deferred kernel + glibc updates are a standing security exposure; activating them was overdue.
+
+### Impacts and Risks
+- Brief downtime during the reboot. The service is `enabled`, came back clean, and the #76 hotfix was verified live afterward (`Export scheduled every 168 hours`).
+- Disk recovered **87% → 80%** (~490M, almost all journal). This is housekeeping, not headroom: a 6.8G root volume is undersized for a JVM + local-Mongo box. If pressure recurs, **grow the EBS volume** rather than scrape further. [open]
+- **Config drift:** the journald cap and the reboot were applied manually on the host — there is no infra-as-code for this box, so this entry is the only durable record. A rebuild would not reproduce the cap. Capturing host config (cloud-init / Ansible) is a possible follow-up. [open]
+
+### Links
+- [Issue #76](https://github.com/nubank/clojuredocs/issues/76) — the deploy that surfaced this
+- [PR #77](https://github.com/nubank/clojuredocs/pull/77) — the export-cadence hotfix deployed in the same session
+
+---
+
 ## 2026-06-24 — Throttle in-process export to weekly (diagnostic for #76)
 
 ### Status


### PR DESCRIPTION
## Context

While deploying the [#76](https://github.com/nubank/clojuredocs/issues/76) export-cadence hotfix ([PR #77](https://github.com/nubank/clojuredocs/pull/77)), the prod host's SSH banner surfaced three warnings: a pending system restart, `/` at **87%** of a **6.8G** root volume, and deferred kernel + glibc security updates that `unattended-upgrades` had installed but never activated.

## Problem

That remediation happened entirely by hand on the box — reboot, journal cleanup, kernel purge, a journald config change. None of it is captured in any repo or IaC, so without a record it's invisible and unreproducible.

## Solution

Add one **Decision Log** entry recording the side quest and the decisions in it:

- **Reboot** to activate the pending kernel + glibc updates (`6.14.0-1011` → `6.17.0-1017`).
- **Cap journald at `SystemMaxUse=200M`** — the journal had grown to ~686M (default ~10% of disk) and was the only meaningfully reclaimable space. Making the one-time vacuum permanent is the reliability ratchet.
- **Purge superseded kernels** as routine hygiene.
- **Keep reboots manual** (no `Unattended-Upgrade::Automatic-Reboot`) — slow `lein run` cold-start on a single-box prod site makes surprise auto-reboots worse than a human-chosen window.

The entry flags two **open items**: the undersized 6.8G volume (grow EBS if pressure recurs rather than keep scraping), and **config drift** — no IaC captures the journald cap, so a rebuild wouldn't reproduce it.

`Refs #76` — documentation only; no app or behavior change. Infra identifiers (host IP/instance ID) deliberately omitted from the committed doc.

<details>
<summary>Father Watson Questions</summary>

- **What do we know?** The host was running months behind on kernel/glibc and the journal had silently grown to ~686M on a tight volume.
- **What do we need to know?** Whether disk pressure recurs (→ grow the volume) and whether host config should move into IaC.
- **Where are we?** Host patched and rebooted, journal capped permanently, disk 87% → 80%; #76 hotfix verified live.
- **Where are we going?** Optional follow-ups: grow the EBS volume; capture host config (cloud-init / Ansible) so the journald cap and reboot policy aren't hand-applied one-offs.

</details>