### PR TITLE
fix: guard note editing against non-authors (#54)

### DIFF
--- a/src/clj/clojuredocs/api/notes.clj
+++ b/src/clj/clojuredocs/api/notes.clj
@@ -28,6 +28,12 @@
     {:status 200
      :body (assoc new-note :can-edit? true :can-delete? true)}))
 
+(defn is-author [user]
+  (fn [m]
+    (when-not (= (select-keys user [:login :account-source])
+                 (select-keys (:author m) [:login :account-source]))
+      {:message "You must be the author of this note."})))
+
 (defn patch-note-handler [id]
   (fn [{:keys [edn-body user]}]
     (c/require-login! user)
@@ -36,17 +42,16 @@
           new-note (-> note
                        (assoc :body (:body edn-body))
                        c/update-timestamps)]
+      (when-not note
+        (throw+
+          {:status 404
+           :body {:message (str "Note with id " id " not found.")}}))
+      (c/validate! note [(is-author user)])
       (c/validate! new-note [body-not-empty])
       (c/validate-schema! new-note Note)
       (mon/update! :notes {:_id (:_id note)} new-note)
       {:status 200
        :body (assoc new-note :can-edit? true :can-delete? true)})))
-
-(defn is-author [user]
-  (fn [m]
-    (when-not (= (select-keys user [:login :account-source])
-                 (select-keys (:author m) [:login :account-source]))
-      {:message "You must be the author of a note to delete it."})))
 
 (defn delete-note-handler [id]
   (fn [{:keys [user]}]

--- a/test/clojuredocs/api/notes_test.clj
+++ b/test/clojuredocs/api/notes_test.clj
@@ -1,0 +1,67 @@
+(ns clojuredocs.api.notes-test
+  "Regression tests for note-editing authorization (issue #54).
+
+  `patch-note-handler` must reject edits from anyone who is not the note's
+  author, mirroring the guard already present on `delete-note-handler`.
+  The Mongo boundary (`fetch-one`/`update!`) is stubbed so these tests run
+  without a live MongoDB while still exercising the real handler wiring."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojuredocs.api.notes :as notes]
+            [somnium.congomongo :as mon]
+            [slingshot.slingshot :refer [try+]]))
+
+(def ^:private note-id "507f1f77bcf86cd799439011")
+
+(def ^:private stored-note
+  {:_id (org.bson.types.ObjectId. note-id)
+   :body "original body"
+   :var {:ns "clojure.core" :name "map"
+         :library-url "https://github.com/clojure/clojure"}
+   :author {:login "alice" :account-source "github"
+            :avatar-url "http://example.com/alice.png"}
+   :created-at 1000
+   :updated-at 1000})
+
+(def ^:private non-author
+  {:login "bob" :account-source "github"
+   :avatar-url "http://example.com/bob.png"})
+
+(deftest patch-note-rejects-non-author
+  (testing "a logged-in user who is not the author cannot edit the note"
+    (with-redefs [mon/fetch-one (fn [& _] stored-note)
+                  mon/update! (fn [& _]
+                                (throw (ex-info "update! must not be reached for a non-author" {})))]
+      (try+
+        (let [resp ((notes/patch-note-handler note-id)
+                    {:edn-body {:body "malicious edit"} :user non-author})]
+          (is false (str "expected a 422 authorization rejection, got status "
+                         (:status resp))))
+        (catch [:status 422] {:keys [body]}
+          (is (re-find #"(?i)author" (:message body))
+              "rejection message should explain the author requirement"))))))
+
+(deftest patch-note-allows-author
+  (testing "the note's own author can edit it (guards against over-restriction)"
+    (let [updated (atom nil)]
+      (with-redefs [mon/fetch-one (fn [& _] stored-note)
+                    mon/update! (fn [_ _ new-note] (reset! updated new-note))]
+        (let [author (:author stored-note)
+              resp ((notes/patch-note-handler note-id)
+                    {:edn-body {:body "an authorized edit"} :user author})]
+          (is (= 200 (:status resp)))
+          (is (= "an authorized edit" (:body (:body resp))))
+          (is (= "an authorized edit" (:body @updated))
+              "the edited body should be persisted"))))))
+
+(deftest patch-note-missing-returns-404
+  (testing "patching a note that does not exist returns 404, not a misleading 422"
+    (with-redefs [mon/fetch-one (fn [& _] nil)
+                  mon/update! (fn [& _]
+                                (throw (ex-info "update! must not be reached for a missing note" {})))]
+      (try+
+        (let [resp ((notes/patch-note-handler note-id)
+                    {:edn-body {:body "edit"} :user non-author})]
+          (is false (str "expected a 404, got status " (:status resp))))
+        (catch [:status 404] {:keys [body]}
+          (is (re-find #"(?i)not found" (:message body))
+              "404 message should say the note was not found"))))))


### PR DESCRIPTION
## Context

Closes #54. `delete-note-handler` checks authorship before deleting a note, but `patch-note-handler` never did.

## Problem

`patch-note-handler` validated only `body-not-empty` + schema. Any logged-in user could PATCH anyone else's note. It also lacked the 404 guard `delete-note-handler` has, so patching a non-existent note fell through to a misleading `422 "not author"` instead of `404`.

## Solution

- Reuse the existing `is-author` predicate on the patch path (`c/validate! note [(is-author user)]`).
- Add the 404 guard mirroring `delete-note-handler`.
- Move `is-author` above its callers and generalize its message (`"...this note."` instead of `"...to delete it."`) — it now serves both edit and delete. Nothing depended on the old string.

Regression tests in `test/clojuredocs/api/notes_test.clj` stub the Mongo boundary (`fetch-one`/`update!`) so they run without a live MongoDB while exercising the real handler wiring:

- non-author PATCH → `422` (was: silently allowed, reached `update!`)
- author PATCH → `200` and persists the edit
- missing note → `404` (was: misleading `422`)

`lein test` — 5 tests, 7 assertions, 0 failures.

<details>
<summary>Father Watson Questions</summary>

- **What do we know?** The delete path already had the guard; the patch path was missing it. Verified against the running handler via `with-redefs` tests.
- **What do we need to know?** Whether any client surfaces the `is-author` message verbatim (grep found no other references; the copy change is cosmetic + more accurate).
- **Where are we?** Both patch failure modes (authz, 404) are closed and regression-tested. This is the first API-handler test in the repo, establishing the stub-the-Mongo-boundary pattern.
- **Where are we going?** #55/#65 live in the same `api/*` neighborhood and can reuse this test pattern.

</details>