### PR TITLE
fix: align dev BASE_URL with server port so GitHub login works (#9)

### DIFF
--- a/bin/.devenv
+++ b/bin/.devenv
@@ -2,7 +2,10 @@
 
 export SESSION_KEY=Uy9V4nWSL2g92OGe
 
-export BASE_URL=http://localhost:5000
+# BASE_URL builds the GitHub OAuth redirect_uri, so it must match the port the
+# server actually listens on — otherwise GitHub rejects the callback (issue #9).
+export BASE_URL=http://localhost:4000
+export PORT=4000
 
 export CLJS_DEV=true
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,7 +4,7 @@ title: Decision Log
 description: Design and architecture decisions; lightweight alternative to full ADRs.
 tags: [decisions, architecture, living-document]
 created: 2026-04-29
-modified: 2026-06-24
+modified: 2026-07-01
 creator: L. Jordan Miller
 ai_assisted: "Claude Opus 4.8 via Claude Code"
 review_maturity: L4
@@ -14,6 +14,38 @@ review_note: Human-endorsed — decisions are the team's; AI-drafted rationale i
 # Decision Log
 
 Document design and architecture decisions. Lightweight alternative to full ADRs.
+
+---
+
+## 2026-07-01 — Pin dev BASE_URL and PORT to :4000 so GitHub login works
+
+### Status
+Decided — shipped in [PR #80](https://github.com/nubank/clojuredocs/pull/80). Fixes the [#9](https://github.com/nubank/clojuredocs/issues/9) login *blocker*, not #9's Add Note button itself.
+
+### Context
+- Resuming the "Now" tier, #9's investigation was blocked because local GitHub OAuth login returned HTTP 403, leaving the logged-in "Add Note" widget unreachable.
+- The OAuth `redirect_uri` is built from `BASE_URL` (`pages/common.clj` → `github/auth-redirect-url`). `bin/.devenv` set `BASE_URL=http://localhost:5000`, but `bin/dev` runs the server on `:4000` (it forces `PORT=4000`) — so dev advertised a `:5000` callback while listening on `:4000`.
+- Verified against the running server: the app never emits a 403 — `gh_auth.clj`'s `callback-handler` only ever `302`s. The 403 is GitHub-side, from the `redirect_uri` mismatch against the dev OAuth app's registered callback. Login already worked under `bin/prod-local`, which uses `:4000` consistently.
+- The prior handoff's leading theory — "dev reuses the *prod* OAuth app whose callback is `clojuredocs.org`" — was **disproven**: dev and prod are separate OAuth apps (`00c7…` vs `d024…`).
+
+### Decision
+- Pin **both** `BASE_URL` and `PORT` to `:4000` in `bin/.devenv`, so the advertised URL and the actual listening port always agree, however the server is started.
+
+### Rationale
+- The root cause is a coupling: `redirect_uri` is derived from `BASE_URL`, so `BASE_URL` must match the real port. Flipping `BASE_URL` alone would leave the manual `source .devenv && lein repl` path broken (server defaults to `:8080`, `main.clj:38`); pinning `PORT` too makes the pair consistent regardless of start method.
+- `:5000` only ever matched the nginx upstream (`resources/nginx.conf`), which is deploy-time and irrelevant when hitting `localhost` directly in dev.
+
+### Impacts and Risks
+- `bin/dev` and manual REPL starts now log in. Verified by equivalence: dev now sends the same `redirect_uri` (`localhost:4000/gh-callback`) that prod-local sent and that a live login succeeded through.
+- Does not touch #9's actual defect (the Add Note button staying disabled) — a separate client-side fix.
+- The `BASE_URL`↔`PORT` coupling is enforced only by these pinned values, not by code; a future divergence could reintroduce the mismatch. A startup assertion (`BASE_URL` port == jetty port) is a possible follow-up ratchet. [open]
+
+### Links
+- [PR #80](https://github.com/nubank/clojuredocs/pull/80)
+- [Issue #9](https://github.com/nubank/clojuredocs/issues/9)
+- [../bin/.devenv](../bin/.devenv)
+- [../src/clj/clojuredocs/pages/gh_auth.clj](../src/clj/clojuredocs/pages/gh_auth.clj)
+- [dev-setup.md](dev-setup.md)
 
 ---
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -4,7 +4,7 @@ title: Dev Environment Setup
 description: Notes for getting a local development environment running.
 tags: [dev-setup, mongodb, leiningen]
 created: 2026-02-27
-modified: 2026-06-16
+modified: 2026-07-01
 review_maturity: L2
 review_note: Human-authored setup notes; frontmatter added during OKF migration.
 ---
@@ -97,5 +97,7 @@ The `:repl-options :init` in `project.clj` loads `reup.clj` on REPL start, which
 ## Web Server
 
 - Default port: **8080** (or whatever `PORT` env var is set to)
-- `bin/dev` sets `PORT=4000`; `bin/.devenv` does not set `PORT`
-- Visit http://localhost:8080 (or your configured port) to verify
+- `bin/.devenv` pins `PORT=4000` and `BASE_URL=http://localhost:4000`; `bin/dev` also sets `PORT=4000`
+- Visit http://localhost:4000 (or your configured port) to verify
+
+> **GitHub login:** `BASE_URL` builds the OAuth `redirect_uri`, so it must match the port the server actually listens on. If they diverge (e.g. `BASE_URL` on `:5000` but the server on `:4000`), GitHub rejects the callback and login fails — see [issue #9](https://github.com/nubank/clojuredocs/issues/9).


### PR DESCRIPTION
## Context
Resuming the "Now" tier handoff, issue #9's investigation was blocked because local GitHub OAuth login returned HTTP 403 — the logged-in "Add Note" widget was unreachable.

## Problem
`bin/.devenv` set `BASE_URL=http://localhost:5000`, but `bin/dev` runs the server on `:4000` (it forces `PORT=4000`). The OAuth `redirect_uri` is built from `BASE_URL` (`pages/common.clj` → `github/auth-redirect-url`), so dev sent GitHub a callback on `:5000` while the server listened on `:4000`. That mismatch is rejected against the dev OAuth app's registered callback and surfaces as a 403 during login.

The app itself cannot emit the 403 — `gh_auth.clj`'s `callback-handler` only ever `302`s (success → session; exception → redirect). The 403 is GitHub-side. Login already succeeds under `bin/prod-local`, which uses `:4000` consistently.

Note: dev and prod are *separate* OAuth apps (`00c7…` vs `d024…`), so this was never about reusing the prod app.

## Solution
Pin both `BASE_URL` and `PORT` to `:4000` in `.devenv` so the advertised URL and the actual listening port always agree, however the server is started. Update `docs/dev-setup.md` to match and document the coupling.

Scope: fixes the **login blocker** only. Issue #9's actual defect (the Add Note button staying disabled) is a separate client-side fix to follow.

<details>
<summary>Father Watson Questions</summary>

- **What we know:** the login 403 is a GitHub-side `redirect_uri` mismatch; the app never 403s; `:4000` works (prod-local), `:5000` (dev) doesn't.
- **What we need to know:** whether any path relies on the old `:5000` — it doesn't; `:5000` only matches the nginx upstream (`nginx.conf`), which is deploy-time, not local dev.
- **Where we are:** dev login unblocked; verified by equivalence with the working prod-local `redirect_uri`.
- **Where we're going:** repro and fix the Add Note button (#9) now that a logged-in session is reachable.
</details>