### PR TITLE
fix: make $add form-2 so the Add Note button reacts to typed text (#9)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -17,6 +17,40 @@ Document design and architecture decisions. Lightweight alternative to full ADRs
 
 ---
 
+## 2026-07-01 — Make $add a form-2 component to fix Add Note reactivity
+
+### Status
+Decided — shipped in [PR #81](https://github.com/nubank/clojuredocs/pull/81). Fixes [#9](https://github.com/nubank/clojuredocs/issues/9) (the "Add Note" button, dead sitewide).
+
+### Context
+- The "Add Note" submit button never enabled. Reproduced against a running client: typing updated the textarea and live preview, but the button's `(empty? text)` gate stayed disabled — and `:text` was stale at submit time. The only console output was a benign `No handler for op ::text-change` println.
+- Root cause: `$add` was a **form-1** component receiving a freshly-built `(rea/cursor !state [:add-note])` on every parent (`$notes`) re-render. Those cursors are value-equal, so Reagent skipped re-rendering `$add` (unchanged args), and the per-render cursor churn dropped its deref subscription. The form-3 `$tabbed-markdown-editor` stayed reactive (it re-renders on its own deref); the form-1 parent did not.
+- This is **not** a cursor bug — cursors notify (the editor proves it). It's specifically form-1 + an inline-created cursor passed as an argument.
+- Two earlier hypotheses were disproven: registering a `::text-change` handler (original handoff) only silences the println — `:text` already updates directly; and "cursors don't work" is contradicted by the editor re-rendering.
+
+### Decision
+- Wrap `$add`'s body in a form-2 render fn (`(fn [] …)`), so it captures one stable cursor and derefs it in a persistent render — the reliably-reactive shape `$edit-note` already uses. No state-model or ops changes.
+
+### Rationale
+- Form-2 gives a stable render closure and a single long-lived cursor subscription, sidestepping both the arg-equality skip and the per-render cursor churn.
+- Minimal and pattern-matched: `$edit-note` (form-2 + local `rea/atom`) already works; this brings `$add` to the same shape without rewiring `handle-new-note`.
+
+### Alternatives Considered
+- **Remove the `(empty? text)` gate** (gate only on `loading?`, like every other button) — rejected: `$add` still wouldn't re-render, so `text` would be stale at submit and post an empty note. Treats the symptom, not the cause.
+- **Refactor `$add` to a local `rea/atom`** (fully mirroring `$edit-note`) — rejected as larger: `handle-new-note` resets/loads through the parent `[:add-note]` cursor, so a local atom would require rewiring the ops handler.
+
+### Impacts and Risks
+- Verified live: the button enables on input and a note posts with the typed text (round-trips), editor collapses.
+- No ClojureScript component-test harness exists, so this is verified by live-client repro — consistent with the project's [REPL/manual verification convention](#2026-04-28--verify-dialect-compat-via-rich-comment-blocks-not-unit-tests). A reactivity regression test is a follow-up if a cljs test setup is stood up. [open]
+- **Latent pattern:** other form-1 components that deref an inline-created cursor could hit the same trap. None currently gate their render on live cursor state, so none are user-visible today — new form-1 + cursor code should prefer form-2. [open]
+
+### Links
+- [PR #81](https://github.com/nubank/clojuredocs/pull/81)
+- [Issue #9](https://github.com/nubank/clojuredocs/issues/9)
+- [../src/cljs/clojuredocs/notes.cljs](../src/cljs/clojuredocs/notes.cljs)
+
+---
+
 ## 2026-07-01 — Pin dev BASE_URL and PORT to :4000 so GitHub login works
 
 ### Status

--- a/src/cljs/clojuredocs/notes.cljs
+++ b/src/cljs/clojuredocs/notes.cljs
@@ -101,55 +101,64 @@
                [:div.null-state "Live Preview"])]]))})))
 
 (defn $add [!state bus]
-  (let [{:keys [expanded? body text error loading?]} @!state
-        comp (rea/current-component)]
-    [:div.add-note
-     [:div.toggle-controls
-      (if true
-        [:a.toggle-link
-         {:href "#"
-          :on-click (fn [e]
-                      (.preventDefault e)
-                      (swap! !state assoc :expanded? (not expanded?))
-                      (when (not expanded?)
-                        (anim/scroll-to
-                          (rea/dom-node comp)
-                          {:pad 10}))
-                      nil)}
-         (if-not expanded?
-           "Add Note"
-           "Collapse")]
-        [:span.muted "log in to add a note"])]
-     [:div.add-note-content {:class (when-not expanded? " hidden")}
-      [:h5 "New Note"]
-      [$tabbed-markdown-editor !state bus]
-      [:p.instructions "Markdown allowed, code in <pre />."]
-      (when error
-        [:div.form-group
-         [:div.error-message.text-danger
-          [:i.fa.fa-exclamation-circle]
-          error]])
-      [:div.add-example-controls.form-group.clearfix
-       [:button {:class "btn btn-default"
-                 :disabled (when loading? "disabled")
-                 :on-click (fn [e]
-                             (.preventDefault e)
-                             (swap! !state
-                               assoc
-                               :expanded? false
-                               :text nil)
-                             nil)}
-        "Cancel"]
-       [:button {:class "btn btn-success pull-right"
-                 :disabled (when (or loading? (empty? text)) "disabled")
-                 :on-click (fn [e]
-                             (.preventDefault e)
-                             (ops/send bus ::new text)
-                             nil)}
-        "Add Note"]
-       [:img.loading.pull-right
-        {:class (when-not loading? " hidden")
-         :src "/img/loading.gif"}]]]]))
+  ;; #9: $add must be form-2. As a form-1 component it received a freshly-built
+  ;; (rea/cursor !state [:add-note]) on every parent ($notes) re-render; those
+  ;; cursors are value-equal, so Reagent skipped re-rendering $add (unchanged
+  ;; args) while the per-render cursor churn dropped its deref subscription.
+  ;; The form-3 editor still updated :text live, but $add never re-rendered, so
+  ;; its (empty? text) submit gate never cleared (and :text was stale at submit
+  ;; time). A form-2 closure captures one stable cursor and derefs it in a
+  ;; persistent render fn — the reliably-reactive shape $edit-note already uses.
+  (fn []
+    (let [{:keys [expanded? body text error loading?]} @!state
+          comp (rea/current-component)]
+      [:div.add-note
+       [:div.toggle-controls
+        (if true
+          [:a.toggle-link
+           {:href "#"
+            :on-click (fn [e]
+                        (.preventDefault e)
+                        (swap! !state assoc :expanded? (not expanded?))
+                        (when (not expanded?)
+                          (anim/scroll-to
+                            (rea/dom-node comp)
+                            {:pad 10}))
+                        nil)}
+           (if-not expanded?
+             "Add Note"
+             "Collapse")]
+          [:span.muted "log in to add a note"])]
+       [:div.add-note-content {:class (when-not expanded? " hidden")}
+        [:h5 "New Note"]
+        [$tabbed-markdown-editor !state bus]
+        [:p.instructions "Markdown allowed, code in <pre />."]
+        (when error
+          [:div.form-group
+           [:div.error-message.text-danger
+            [:i.fa.fa-exclamation-circle]
+            error]])
+        [:div.add-example-controls.form-group.clearfix
+         [:button {:class "btn btn-default"
+                   :disabled (when loading? "disabled")
+                   :on-click (fn [e]
+                               (.preventDefault e)
+                               (swap! !state
+                                 assoc
+                                 :expanded? false
+                                 :text nil)
+                               nil)}
+          "Cancel"]
+         [:button {:class "btn btn-success pull-right"
+                   :disabled (when (or loading? (empty? text)) "disabled")
+                   :on-click (fn [e]
+                               (.preventDefault e)
+                               (ops/send bus ::new text)
+                               nil)}
+          "Add Note"]
+         [:img.loading.pull-right
+          {:class (when-not loading? " hidden")
+           :src "/img/loading.gif"}]]]])))
 
 (defn $edit-note [{:keys [_id error body loading? editing?] :as note} bus]
   (let [!local (rea/atom {:text body

--- a/src/cljs/clojuredocs/notes.cljs
+++ b/src/cljs/clojuredocs/notes.cljs
@@ -114,21 +114,19 @@
           comp (rea/current-component)]
       [:div.add-note
        [:div.toggle-controls
-        (if true
-          [:a.toggle-link
-           {:href "#"
-            :on-click (fn [e]
-                        (.preventDefault e)
-                        (swap! !state assoc :expanded? (not expanded?))
-                        (when (not expanded?)
-                          (anim/scroll-to
-                            (rea/dom-node comp)
-                            {:pad 10}))
-                        nil)}
-           (if-not expanded?
-             "Add Note"
-             "Collapse")]
-          [:span.muted "log in to add a note"])]
+        [:a.toggle-link
+         {:href "#"
+          :on-click (fn [e]
+                      (.preventDefault e)
+                      (swap! !state assoc :expanded? (not expanded?))
+                      (when (not expanded?)
+                        (anim/scroll-to
+                          (rea/dom-node comp)
+                          {:pad 10}))
+                      nil)}
+         (if-not expanded?
+           "Add Note"
+           "Collapse")]]
        [:div.add-note-content {:class (when-not expanded? " hidden")}
         [:h5 "New Note"]
         [$tabbed-markdown-editor !state bus]


### PR DESCRIPTION
## Context
[Issue #9](https://github.com/nubank/clojuredocs/issues/9): the "Add Note" button is dead sitewide — it never enables. This is the actual client-side defect; the login blocker that hid it was fixed separately in #80.

## Problem
`$add` was a **form-1** component that received a freshly-built `(rea/cursor !state [:add-note])` on every parent (`$notes`) re-render. Those cursors are *value-equal*, so Reagent treated `$add`'s args as unchanged and skipped re-rendering it, while the per-render cursor churn dropped `$add`'s own deref subscription.

Result: the form-3 `$tabbed-markdown-editor` updated `:text` live (textarea + preview reacted), but `$add` never re-rendered — so its `(empty? text)` submit gate never cleared, and `text` was also **stale at submit time** (removing the gate alone would have posted an empty note).

This is *not* a cursor bug — the editor proves cursors notify. It's form-1 + inline-cursor churn. The sibling `$edit-note` doesn't hit it because it's a **form-2** component holding a stable local `rea/atom`.

## Solution
Wrap `$add`'s body in a form-2 render fn (`(fn [] …)`), so it captures one stable cursor and derefs it in a persistent render — the reliably-reactive shape `$edit-note` already uses. No state-model or ops changes; `handle-new-note` coordination is untouched.

**Verified in a running client:** the button enables on input, and a note posts with the typed text (round-trips byte-for-byte), editor collapses.

Note: this repo has no ClojureScript component-test harness, so verification is the live-client repro (consistent with the project's [existing convention](docs/decisions.md) of REPL/manual verification over unit tests for the cljs layer). A reactivity regression test is a possible follow-up if we stand up a cljs test setup.

<details>
<summary>Father Watson Questions</summary>

- **What we know:** form-3 editor is reactive; form-1 `$add` was not (button gate stuck, `:text` stale at submit). Confirmed by live repro: text + preview updated, button stayed disabled, only console output was the benign `No handler for op ::text-change` println.
- **What we need to know:** whether other form-1 components that deref inline-created cursors have the same latent issue (none currently gate render on live cursor state, so none are user-visible).
- **Where we are:** fixed and verified live — button enables, note posts.
- **Where we're going:** the disproven `::text-change` handler theory from the original handoff is now moot; that op stays intentionally unhandled.
</details>