### PR TITLE
refactor: drop index decls for non-existent collections (#70)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -51,6 +51,35 @@ Decided — shipped in [PR #81](https://github.com/nubank/clojuredocs/pull/81). 
 
 ---
 
+## 2026-07-01 — Drop startup index decls for non-existent collections
+
+### Status
+Decided — shipped in [PR #82](https://github.com/nubank/clojuredocs/pull/82). Follow-on to [PR #61](https://github.com/nubank/clojuredocs/pull/61); closes [#70](https://github.com/nubank/clojuredocs/issues/70).
+
+### Context
+- `add-all-indexes!` (run at server boot) declared indexes for `:namespaces`, `:libraries`, and `:migrate-users`.
+- Audit: none are read or written anywhere in `src/clj` (every `:namespaces` occurrence is a map key, not a collection), none exist in the `data/mongodb/` dump, and the only references are in the dead `tools/old_import.clj`. So boot created three empty collections.
+- Before #61 the calls were inert — `add-indexes-to-coll!` ignored its `coll` arg and only ever indexed `:examples`. #61 made `coll` honored, which is what made these decls actually materialize the empty collections, and what makes the cleanup meaningful now.
+
+### Decision
+- Remove the `:namespaces`, `:libraries`, and `:migrate-users` index declarations. Keep the ones backed by real, queried collections: `:examples`, `:see-alsos`, `:notes`, `:users`, `:legacy-var-redirects`.
+
+### Rationale
+- Indexing collections that never receive documents is pure noise — it materializes empty collections and misleads anyone reading `add-all-indexes!` as a map of the data model.
+- `:legacy-var-redirects` is kept deliberately: it is queried (`entry.clj`) and present in the dump.
+
+### Impacts and Risks
+- No behavior change to any real feature; boot simply stops creating three empty collections.
+- **Noted, not addressed here:** the inverse gap — `:vars`, `:job-metrics`, and `:example-histories` are queried but have *no* index declarations. Adding those is a separate follow-up, kept out of this single-purpose cleanup. [open]
+
+### Links
+- [PR #82](https://github.com/nubank/clojuredocs/pull/82)
+- [Issue #70](https://github.com/nubank/clojuredocs/issues/70)
+- [PR #61](https://github.com/nubank/clojuredocs/pull/61)
+- [../src/clj/clojuredocs/main.clj](../src/clj/clojuredocs/main.clj)
+
+---
+
 ## 2026-07-01 — Pin dev BASE_URL and PORT to :4000 so GitHub login works
 
 ### Status

--- a/src/clj/clojuredocs/main.clj
+++ b/src/clj/clojuredocs/main.clj
@@ -59,14 +59,10 @@
                :author.login :author.account-source
                :editors.login :editors.account-source])
 
-  (add-indexes-to-coll! :namespaces [:name])
-
   (add-indexes-to-coll!
     :see-alsos [:from-var.name :from-var.ns :from-var.library-url
                 :to-var.ns :to-var.name :to-var.library-url
                 :account.login :account.account-source])
-
-  (add-indexes-to-coll! :libraries [:namespaces])
 
   (add-indexes-to-coll!
     :notes [:var.ns :var.name :var.library-url
@@ -76,9 +72,7 @@
     :legacy-var-redirects [:function-id
                            :editor.login :editor.account-source])
 
-  (add-indexes-to-coll! :users [:login :account-source])
-
-  (add-indexes-to-coll! :migrate-users [:email :migration-key]))
+  (add-indexes-to-coll! :users [:login :account-source]))
 
 (def ^:private export-path "resources/public/clojuredocs-export.json")
 


### PR DESCRIPTION
## Context
Follow-on to [#61](https://github.com/nubank/clojuredocs/pull/61) (which made `add-indexes-to-coll!` honor its `coll` arg). [Issue #70](https://github.com/nubank/clojuredocs/issues/70): audit and drop index declarations that no longer make sense now that `coll` is honored.

## Problem
`add-all-indexes!` declared indexes for `:namespaces`, `:libraries`, and `:migrate-users`. Audit findings:
- **Not read or written** anywhere in the app (`src/clj`) — every `:namespaces` hit is a map *key*, not a Mongo collection.
- **Absent from the data dump** — `data/mongodb/` has no `namespaces`/`libraries`/`migrate-users` BSON.
- **Only referenced by dead code** — `tools/old_import.clj` (a one-time legacy import; one ref is even `#_`-commented).

So on every boot these created three empty collections. Before #61 it was inert (the fn ignored `coll` and only ever indexed `:examples`); #61 made it real, which is what makes this cleanup worth doing now.

## Solution
Remove the three declarations. Keep everything backed by a real, queried collection: `:examples`, `:see-alsos`, `:notes`, `:users`, and `:legacy-var-redirects` (queried in `entry.clj:80`, present in the dump).

Verified: `main.clj` parses (13 top-level forms, balanced).

<details>
<summary>Father Watson Questions</summary>

- **What we know:** the three dropped collections have zero app reads/writes and no seed data; `:legacy-var-redirects` is real and stays.
- **What we need to know:** nothing blocking. Separately noted (not in scope): `:vars`, `:job-metrics`, and `:example-histories` are *queried* but have **no** index declarations — a possible follow-up (add indexes), the inverse of this cleanup.
- **Where we are:** three empty-collection index decls removed.
- **Where we're going:** optionally audit the missing-index side next.
</details>