### PR TITLE
fix: send search tracking to Matomo instead of dead js/ga (#24)

### DIFF
--- a/src/cljs/clojuredocs/metrics.cljs
+++ b/src/cljs/clojuredocs/metrics.cljs
@@ -1,12 +1,18 @@
 (ns clojuredocs.metrics)
 
 (defn track-event
-  "Records a Matomo custom event (Behaviour > Events). `name` and
-   `value` are optional; Matomo expects `value` to be numeric when given."
+  "Records a Matomo custom event (Behaviour > Events). `name` and `value`
+   are optional but positional — Matomo reads trackEvent as
+   [category action name value], so an absent `name` alongside a present
+   `value` must keep its slot (else the value is recorded as the name).
+   `value` should be numeric when given."
   ([category action] (track-event category action nil nil))
   ([category action name] (track-event category action name nil))
   ([category action name value]
-   (.push js/_paq (clj->js (remove nil? ["trackEvent" category action name value])))))
+   (let [args (cond-> ["trackEvent" category action]
+                (or name value) (conj name)
+                value           (conj value))]
+     (.push js/_paq (clj->js args)))))
 
 (defn track-search
   "Records a Matomo site-search event (Behaviour > Site Search) so

--- a/src/cljs/clojuredocs/metrics.cljs
+++ b/src/cljs/clojuredocs/metrics.cljs
@@ -1,10 +1,18 @@
 (ns clojuredocs.metrics)
 
-(defn ga-event [category action label value]
-  (js/ga "send" "event" category action label value))
+(defn track-event
+  "Records a Matomo custom event (Behaviour > Events). `name` and
+   `value` are optional; Matomo expects `value` to be numeric when given."
+  ([category action] (track-event category action nil nil))
+  ([category action name] (track-event category action name nil))
+  ([category action name value]
+   (.push js/_paq (clj->js (remove nil? ["trackEvent" category action name value])))))
 
-(defn track-search [query]
-  (ga-event "search" query "count" 1))
+(defn track-search
+  "Records a Matomo site-search event (Behaviour > Site Search) so
+   query terms and result counts are visible, including zero-result queries."
+  [query result-count]
+  (.push js/_paq #js ["trackSiteSearch" query false result-count]))
 
 (defn track-search-choose [query choice]
-  (ga-event "search-choose" query choice 1))
+  (track-event "search" "select-result" (str query " -> " choice)))

--- a/src/cljs/clojuredocs/mods/search.cljs
+++ b/src/cljs/clojuredocs/mods/search.cljs
@@ -336,7 +336,7 @@
                                     :results-empty? (and (empty? data) (not (empty? ac-text)))
                                     :ac-results data
                                     :search-loading? false})))
-                             #_(metrics/track-search ac-text)))))
+                             (metrics/track-search ac-text (count data))))))
                      (close! ch))
                    ch))
 
@@ -352,13 +352,15 @@
                                  (dissoc state :search-loading? :ac-results :ac-text :results-empty?))
 
                ::ac-select (fn [state res]
-                             (util/navigate-to
-                               (or (:href res)
-                                   (util/var-path
-                                     (:ns res)
-                                     (:name res))))
+                             (let [href (or (:href res)
+                                            (util/var-path
+                                              (:ns res)
+                                              (:name res)))]
+                               (metrics/track-search-choose (:ac-text state) href)
+                               (util/navigate-to href))
                              nil)
                ::var-search (fn [state text]
+                              (metrics/track-event "search" "submit-full-search" text)
                               (util/navigate-to
                                 (str "/search?q=" (util/url-encode text)))
                               nil)})]


### PR DESCRIPTION
## Context

Part of the [#24](https://github.com/nubank/clojuredocs/issues/24) analytics baseline. Client-side search tracking in [`metrics.cljs`](../blob/master/src/cljs/clojuredocs/metrics.cljs) targeted `js/ga` — a Google Analytics global that no longer loads anywhere in the app (only Matomo's `_paq` is injected, in [`common.clj` L17-28](../blob/master/src/clj/clojuredocs/pages/common.clj#L17-L28)). Every search-tracking call was either dead or `#_`-discarded, so we capture zero search behavior today.

## Problem

We have no data on what users search for, whether they find it, or which results they pick — the largest blind spot in the #24 baseline. Search-query and zero-result data can only accrue *forward* from the day tracking ships, so the cost of leaving this dead is a permanently unrecoverable gap in the pre-redesign baseline.

## Solution

Repoint the tracking to Matomo's `_paq`:

- `track-search` now calls `trackSiteSearch` with the result count, so queries land in Matomo's Site Search report **including zero-result queries**.
- `track-search-choose` and a new `submit-full-search` event use `trackEvent`.
- Wire these into the **live** search handlers in `init` (`::ac-text-throttled`, `::ac-select`, `::var-search`). The old calls in `wire-search` are dead code (never called) and stay `#_`-discarded — untouched here, flagged as a possible follow-up cleanup.

## Father Watson Questions

<details>
<summary>Verification status and open questions</summary>

- **What do we know?** Static verification is clean: all live call sites match the new arities; the `#_`-discarded calls in dead `wire-search` are inert; `_paq` is defined globally in `common.clj`; and an **advanced (`:optimizations :advanced`) ClojureScript compile succeeds with zero warnings on the changed files** — which would have caught unresolved symbols, bad interop, or arity mismatches.
- **What do we need to know?** Whether the events actually fire and reach Matomo. **This has not been verified at runtime** — no `bin/dev` browser session, no confirmation of `matomo.php` calls in the network tab or of events appearing in the Matomo dashboard (`idSite=15`). That is the merge gate: exercise autocomplete search, result-select, and full-search-submit, and confirm the Site Search report + events populate.
- **Where are we?** Compiles clean; logic verified statically; not yet exercised live.
- **Where are we going?** Once confirmed firing, this closes the "no search data" blind spot in #24 and starts the search-behavior baseline clock. Site Search data then needs a bake-in period before it's meaningful.

</details>

Refs #24.
