### PR TITLE
fix: find star-prefixed vars via exact-name search

### DIFF
--- a/src/clj/clojuredocs/search.clj
+++ b/src/clj/clojuredocs/search.clj
@@ -37,7 +37,7 @@
      :skip-wiki])
 
 (defn impl-var?
-  "Returns true if a var is an implementation detail — either marked
+  "Returns true if a var is an implementation detail â€” either marked
    ^:skip-wiki or lacking a docstring (the same heuristic Clojure's
    official docs use to omit internal vars)."
   [{:keys [skip-wiki doc special-form]}]
@@ -189,7 +189,7 @@ Still maintains the O(n*m) guarantee.
 (defn drop-leading-stars
   "Strip leading '*' characters that users type as a wildcard prefix.
 
-  Only leading stars are removed (`^*+`). Names that *are* the stars-plus-rest
+  Only leading stars are removed (`^\*+`, regex `#"^\*+"`). Names that *are* the stars-plus-rest
   identifier (e.g. `*'`, `*1`) are recovered via `exact-name-matches` before
   this runs, so we do not erase the identifier itself."
   [q]
@@ -218,8 +218,7 @@ Still maintains the O(n*m) guarantee.
       (filterv #(= (str/lower-case (:name %)) q') searchable-vars))))
 
 (defn query [q]
-  (let [trimmed (some-> q str/trim)
-        exact (exact-name-matches trimmed)]
+  (let [trimmed (some-> q str/trim)]
     (cond
       ;; Bare `*` is both a wildcard and the real var `clojure.core/*`.
       (= "*" trimmed)
@@ -229,8 +228,15 @@ Still maintains the O(n*m) guarantee.
       ;; short-circuit: `drop-leading-stars` would otherwise strip the leading
       ;; asterisks and Lucene would never see the real identifier.
       ;; See https://github.com/nubank/clojuredocs/issues/87
-      (and (seq exact) trimmed (.startsWith trimmed "*"))
-      exact
+      ;; Only run the O(n) exact-name scan for star-prefixed queries.
+      (and trimmed (.startsWith trimmed "*"))
+      (let [exact (exact-name-matches trimmed)]
+        (if (seq exact)
+          exact
+          (when-let [formatted (format-query trimmed)]
+            (->> (clucy/search search-index formatted 1000 :default-field "keywords")
+                 (map #(assoc % :edit-distance (levenshtein-distance (str (:name %)) formatted)))
+                 (sort-by :edit-distance)))))
 
       :else
       (when-let [formatted (format-query trimmed)]

--- a/src/clj/clojuredocs/search.clj
+++ b/src/clj/clojuredocs/search.clj
@@ -186,12 +186,15 @@ Still maintains the O(n*m) guarantee.
       (map #(identity %2) (cons nil b) (range))
       a)))
 
-(defn drop-leading-stars [q]
+(defn drop-leading-stars
+  "Strip leading '*' characters that users type as a wildcard prefix.
+
+  Only leading stars are removed (`^*+`). Names that *are* the stars-plus-rest
+  identifier (e.g. `*'`, `*1`) are recovered via `exact-name-matches` before
+  this runs, so we do not erase the identifier itself."
+  [q]
   (when q
-    (let [stripped (if (.startsWith q "*")
-                     (->> (str/replace q #"\**" "")
-                          (apply str))
-                     q)]
+    (let [stripped (str/replace q #"^\*+" "")]
       (when-not (empty? stripped)
         stripped))))
 
@@ -207,12 +210,30 @@ Still maintains the O(n*m) guarantee.
     lucene-escape
     (str "*")))
 
-(defn query [q]
-  (cond
-    (= "*" q) [(lookup "clojure.core/*")]
+(defn exact-name-matches
+  "Return searchable vars whose `:name` equals `q` (case-insensitive, trimmed)."
+  [q]
+  (when-not (str/blank? q)
+    (let [q' (str/lower-case (str/trim q))]
+      (filterv #(= (str/lower-case (:name %)) q') searchable-vars))))
 
-    :else
-    (when-let [q (format-query q)]
-      (->> (clucy/search search-index q 1000 :default-field "keywords")
-           (map #(assoc % :edit-distance (levenshtein-distance (str (:name %)) q)))
-           (sort-by :edit-distance)))))
+(defn query [q]
+  (let [trimmed (some-> q str/trim)
+        exact (exact-name-matches trimmed)]
+    (cond
+      ;; Bare `*` is both a wildcard and the real var `clojure.core/*`.
+      (= "*" trimmed)
+      [(lookup "clojure.core/*")]
+
+      ;; Vars whose names start with `*` (e.g. `*'`, `*1`, `*agent*`) must
+      ;; short-circuit: `drop-leading-stars` would otherwise strip the leading
+      ;; asterisks and Lucene would never see the real identifier.
+      ;; See https://github.com/nubank/clojuredocs/issues/87
+      (and (seq exact) trimmed (.startsWith trimmed "*"))
+      exact
+
+      :else
+      (when-let [formatted (format-query trimmed)]
+        (->> (clucy/search search-index formatted 1000 :default-field "keywords")
+             (map #(assoc % :edit-distance (levenshtein-distance (str (:name %)) formatted)))
+             (sort-by :edit-distance))))))

--- a/test/clojuredocs/search_test.clj
+++ b/test/clojuredocs/search_test.clj
@@ -1,0 +1,33 @@
+(ns clojuredocs.search-test
+  "Regression tests for search formatting / exact-name hits (issue #87)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojuredocs.search :as search]))
+
+(deftest exact-name-matches-star-quote
+  (testing "clojure.core/*' is findable by its literal name"
+    (let [hits (search/exact-name-matches "*'")]
+      (is (seq hits) "expected at least one exact hit for *'")
+      (is (some #(= "*'" (:name %)) hits)))))
+
+(deftest query-finds-star-quote
+  (testing "searching *' returns clojure.core/*' (does not collapse to -')"
+    (let [hits (vec (search/query "*'"))
+          names (map :name hits)]
+      (is (some #(= "*'" %) names)
+          (str "expected *' in results, got: " (pr-str names)))
+      (is (not-any? #(= "-'" %) names)
+          "must not exclusively/incorrectly surface -' for a *' query"))))
+
+(deftest query-bare-star-still-resolves-core-star
+  (testing "searching bare * still resolves clojure.core/*"
+    (let [hits (vec (search/query "*"))]
+      (is (= 1 (count hits)))
+      (is (= "*" (:name (first hits))))
+      (is (= "clojure.core" (:ns (first hits)))))))
+
+(deftest drop-leading-stars-only-strips-prefix
+  (testing "only leading asterisks are stripped (not every * in the string)"
+    (is (= "agent*" (search/drop-leading-stars "*agent*")))
+    (is (= "'" (search/drop-leading-stars "*'")))
+    (is (nil? (search/drop-leading-stars "*")))
+    (is (= "map" (search/drop-leading-stars "map")))))


### PR DESCRIPTION
## Summary
- Exact-name short-circuit for star-prefixed vars so queries like `*'` hit `clojure.core/*'` instead of being mangled by `drop-leading-stars`.
- Restrict star-stripping to a leading wildcard prefix (`^*+`) only.
- Add regression tests for exact match, bare `*`, and drop-leading-stars behavior.

## Why
Leading asterisks were stripped from the query before Lucene search, so identifiers that legitimately start with `*` never matched. The var page for `clojure.core/*'` existed; search did not surface it.

Fixes #87

## Test plan
- [x] Added `test/clojuredocs/search_test.clj`
- [ ] `lein test clojuredocs.search-test` (or full suite) in CI / maintainer env

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/