### PR TITLE
fix: store previous example body in edit history

### DIFF
--- a/src/clj/clojuredocs/api/examples.clj
+++ b/src/clj/clojuredocs/api/examples.clj
@@ -14,10 +14,12 @@
   (mon/insert! :examples payload)
   payload)
 
-(defn create-example-history [example user new-body]
+(defn create-example-history
+  "Creates a history record capturing the example body being replaced."
+  [example user previous-body]
   {:_id (org.bson.types.ObjectId.)
    :editor user
-   :body new-body
+   :body previous-body
    :created-at (util/now)
    :example-id (:_id example)})
 
@@ -84,7 +86,7 @@
           example-history (create-example-history
                             example
                             user
-                            (:body example-update))]
+                            (:body example))]
       (when-not example
         (throw+
           (-> (edn-response {:error "Couldn't find the example you're trying to update."})

--- a/test/clojuredocs/api/examples_history_test.clj
+++ b/test/clojuredocs/api/examples_history_test.clj
@@ -1,0 +1,42 @@
+(ns clojuredocs.api.examples-history-test
+  "Regression tests for example history body capture (issue #55).
+
+  When an example is edited, history must store the *previous* body
+  (the content being replaced), not the incoming request body."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojuredocs.api.examples :as examples]
+            [somnium.congomongo :as mon]))
+
+(def ^:private example-id "507f1f77bcf86cd799439011")
+
+(def ^:private stored-example
+  {:_id (org.bson.types.ObjectId. example-id)
+   :body "original content"
+   :var {:ns "clojure.core" :name "map"
+         :library-url "https://github.com/clojure/clojure"}
+   :author {:login "alice" :account-source "github"
+            :avatar-url "http://example.com/alice.png"}
+   :editors []
+   :created-at 1000
+   :updated-at 1000})
+
+(def ^:private editor
+  {:login "bob" :account-source "github"
+   :avatar-url "http://example.com/bob.png"})
+
+(deftest patch-example-history-stores-previous-body
+  (testing "history entry body is the pre-edit content, not the new payload"
+    (let [history (atom nil)]
+      (with-redefs [mon/fetch-one (fn [& _] stored-example)
+                    mon/update! (fn [& _] nil)
+                    mon/insert! (fn [coll doc]
+                                  (when (= coll :example-histories)
+                                    (reset! history doc)))]
+        (let [resp ((examples/patch-example-handler example-id)
+                    {:edn-body {:body "revised content"} :user editor})]
+          (is (= 200 (:status resp)))
+          (is (= "revised content" (:body (:body resp)))
+              "current example should hold the new body")
+          (is (= "original content" (:body @history))
+              "history must preserve the body being replaced")
+          (is (= (:_id stored-example) (:example-id @history))))))))


### PR DESCRIPTION
## Summary
- `create-example-history` now stores the **previous** example body (content being replaced).
- `patch-example-handler` passes `(:body example)` instead of the incoming request body.
- Adds a handler-level regression test with Mongo stubs.

## Why
History entries recorded what each edit changed the body *to*, so the original pre-first-edit content was never captured.

Fixes #55

## Test plan
- [x] Added `test/clojuredocs/api/examples_history_test.clj`
- [ ] `lein test clojuredocs.api.examples-history-test` in CI / maintainer env

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/