### PR TITLE
test: guard dialect-compat cardinality and Clojure version

### DIFF
--- a/test/clojuredocs/entity_model_test.clj
+++ b/test/clojuredocs/entity_model_test.clj
@@ -228,6 +228,16 @@
     (is (map? (:vars compat/dialect-compat)))
     (is (map? (:versions compat/dialect-compat)))))
 
+(deftest dialect-compat-cardinality
+  ;; Guards the EDN `:cardinality` string against silent drift (#69).
+  (let [vars-count  (count (:vars compat/dialect-compat))
+        pairs-count (reduce + 0 (map count (vals (:vars compat/dialect-compat))))
+        expected    (str vars-count " vars / " pairs-count " var-dialect pairs")
+        documented  (get-in schema [:entities :dialect-compat :cardinality])]
+    (is (= documented expected)
+        (str "dialect-compat cardinality drift: EDN has " (pr-str documented)
+             " but data has " expected))))
+
 (deftest dialect-compat-lookup-works
   (testing "known vars return expected dialect sets"
     (is (= #{:bb :clj :cljs} (compat/dialects-for "clojure.core" "map")))
@@ -241,6 +251,17 @@
       (doseq [d dialects]
         (is (keyword? d)
             (str var-key " contains non-keyword dialect: " d))))))
+
+;; --- Clojure version guard (#68) ---
+
+(deftest schema-verified-against-classpath-clojure
+  (testing "search/clojure-lib version matches the classpath Clojure version"
+    (let [pinned (:version search/clojure-lib)
+          running (clojure-version)]
+      (is (= pinned running)
+          (str "entity-model counts are pinned to Clojure " pinned
+               " but classpath has " running
+               " — bump search.clj / regenerate the model")))))
 
 ;; --- Cross-entity consistency ---
 


### PR DESCRIPTION
## Summary
- Assert `:dialect-compat :cardinality` stays in lockstep with live var/pair counts (715 / 1880 today).
- Assert `(:version search/clojure-lib)` equals `(clojure-version)` so version-pinned entity-model counts fail with one clear signal on Clojure bumps.

## Why
#69: cardinality drifted once with no test guard. #68: bumping Clojure currently fails many count assertions without explaining the version coupling.

Fixes #69
Fixes #68

## Test plan
- [ ] `lein test clojuredocs.entity-model-test` (needs full ClojureDocs classpath / CI)
- [x] Assertions mirror the issue reproduction steps


---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/